### PR TITLE
=use WebUtility.HtmlEncode instead of System.Web.HttpUtility

### DIFF
--- a/InertiaCore/ResponseFactory.cs
+++ b/InertiaCore/ResponseFactory.cs
@@ -77,7 +77,7 @@ internal class ResponseFactory : IResponseFactory
                 ReferenceHandler = ReferenceHandler.IgnoreCycles
             });
 
-        var encoded =  WebUtility.HtmlEncode(data);
+        var encoded = WebUtility.HtmlEncode(data);
 
         return new HtmlString($"<div id=\"app\" data-page=\"{encoded}\"></div>");
     }

--- a/InertiaCore/ResponseFactory.cs
+++ b/InertiaCore/ResponseFactory.cs
@@ -1,6 +1,6 @@
+using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Web;
 using InertiaCore.Extensions;
 using InertiaCore.Ssr;
 using Microsoft.AspNetCore.Html;
@@ -77,7 +77,7 @@ internal class ResponseFactory : IResponseFactory
                 ReferenceHandler = ReferenceHandler.IgnoreCycles
             });
 
-        var encoded = HttpUtility.HtmlEncode(data);
+        var encoded =  WebUtility.HtmlEncode(data);
 
         return new HtmlString($"<div id=\"app\" data-page=\"{encoded}\"></div>");
     }


### PR DESCRIPTION
The `System.Web.HttpUtility` class in .NET Core 6+ no longer includes the HtmlEncode method. Instead, we can use the 
`WebUtility.HtmlEncode` method from the `System.Net namespace` to encode HTML strings.

fixes #4 