### PR TITLE
Add a Vite helper

### DIFF
--- a/InertiaCore/Extensions/Configure.cs
+++ b/InertiaCore/Extensions/Configure.cs
@@ -1,3 +1,4 @@
+using System.IO.Abstractions;
 using System.Net;
 using InertiaCore.Models;
 using InertiaCore.Ssr;
@@ -16,6 +17,9 @@ public static class Configure
     {
         var factory = app.ApplicationServices.GetRequiredService<IResponseFactory>();
         Inertia.UseFactory(factory);
+
+        var viteBuilder = app.ApplicationServices.GetService<IViteBuilder>();
+        if (viteBuilder != null) Vite.UseBuilder(viteBuilder);
 
         app.Use(async (context, next) =>
         {
@@ -44,6 +48,15 @@ public static class Configure
 
         services.Configure<MvcOptions>(mvcOptions => { mvcOptions.Filters.Add<InertiaActionFilter>(); });
 
+        if (options != null) services.Configure(options);
+
+        return services;
+    }
+
+    public static IServiceCollection AddViteHelper(this IServiceCollection services,
+        Action<ViteOptions>? options = null)
+    {
+        services.AddSingleton<IViteBuilder, ViteBuilder>();
         if (options != null) services.Configure(options);
 
         return services;

--- a/InertiaCore/InertiaCore.csproj
+++ b/InertiaCore/InertiaCore.csproj
@@ -21,7 +21,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="TypeMerger" Version="2.1.1"/>
+        <PackageReference Include="System.IO.Abstractions" Version="19.2.1" />
+        <PackageReference Include="TypeMerger" Version="2.1.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/InertiaCore/InertiaCore.csproj
+++ b/InertiaCore/InertiaCore.csproj
@@ -29,4 +29,8 @@
         <None Include="../LICENSE" Pack="true" PackagePath=""/>
         <None Include="../README.md" Pack="true" PackagePath=""/>
     </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    </ItemGroup>
 </Project>

--- a/InertiaCore/InertiaCore.csproj
+++ b/InertiaCore/InertiaCore.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.IO.Abstractions" Version="19.2.1" />
+        <PackageReference Include="System.IO.Abstractions" Version="19.2.16" />
         <PackageReference Include="TypeMerger" Version="2.1.1" />
     </ItemGroup>
 

--- a/InertiaCore/InertiaCore.csproj
+++ b/InertiaCore/InertiaCore.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
     <ItemGroup>
@@ -26,8 +26,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="../LICENSE" Pack="true" PackagePath=""/>
-        <None Include="../README.md" Pack="true" PackagePath=""/>
+        <None Include="../LICENSE" Pack="true" PackagePath="" />
+        <None Include="../README.md" Pack="true" PackagePath="" />
     </ItemGroup>
 
     <ItemGroup>

--- a/InertiaCore/Models/ViteOptions.cs
+++ b/InertiaCore/Models/ViteOptions.cs
@@ -1,0 +1,16 @@
+namespace InertiaCore.Models;
+
+public class ViteOptions
+{
+    // The path to the "hot" file.
+    public string HotFile { get; set; } = "hot";
+
+    // The path to the build directory.
+    public string? BuildDirectory { get; set; } = "build";
+
+    // The name of the manifest file.
+    public string ManifestFilename { get; set; } = "manifest.json";
+
+    // The path to the public directory.
+    public string PublicDirectory { get; set; } = "wwwroot";
+}

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -118,7 +118,7 @@ internal class ViteBuilder : IViteBuilder
     {
         if (isRunningHot())
         {
-            return new HtmlString(makeModuleTag(hotAsset("@vite/client")) + makeModuleTag(hotAsset(path)));
+            return new HtmlString(makeModuleTag(asset("@vite/client")) + makeModuleTag(asset(path)));
         }
 
         if (!_fileSystem.File.Exists(getPublicPathForFile(manifestFilename)))
@@ -224,7 +224,7 @@ internal class ViteBuilder : IViteBuilder
         builder.Attributes.Add("type", "module");
 
         var inner = String.Format(
-            "import RefreshRuntime from '{0}';", hotAsset("@react-refresh")) +
+            "import RefreshRuntime from '{0}';", asset("@react-refresh")) +
             "RefreshRuntime.injectIntoGlobalHook(window);" +
             "window.$RefreshReg$ = () => { };" +
             "window.$RefreshSig$ = () => (type) => type;" +

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -46,7 +46,7 @@ internal class ViteBuilder : IViteBuilder
 
     private readonly IFileSystem _fileSystem;
 
-    public static ViteBuilder? instance = null;
+    private static ViteBuilder? instance = null;
     public static ViteBuilder Instance
     {
         get

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -22,27 +22,31 @@ public static class Vite
     private static string publicDirectory = "wwwroot";
 
     // Set the filename for the manifest file.
-    public static string useManifestFilename(string newManifestFilename)
+    public static string? useManifestFilename(string newManifestFilename)
     {
-        return manifestFilename = newManifestFilename;
+        manifestFilename = newManifestFilename;
+        return null;
     }
 
     // Set the Vite "hot" file path.
-    public static string useHotFile(string newHotFile)
+    public static string? useHotFile(string newHotFile)
     {
-        return hotFile = newHotFile;
+        hotFile = newHotFile;
+        return null;
     }
 
     //  Set the Vite build directory.
     public static string? useBuildDir(string? newBuildDirectory)
     {
-        return buildDirectory = newBuildDirectory;
+        buildDirectory = newBuildDirectory;
+        return null;
     }
 
     //  Set the public directory.
-    public static string usePublicDir(string newPublicDirectory)
+    public static string? usePublicDir(string newPublicDirectory)
     {
-        return publicDirectory = newPublicDirectory;
+        publicDirectory = newPublicDirectory;
+        return null;
     }
 
     //  Get the public directory and build path.

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -6,63 +6,48 @@ using System.Text.RegularExpressions;
 
 namespace InertiaCore.Utils;
 
-public static class Vite
-{
 
+class ViteBuilder
+{
     // The path to the "hot" file.
-    private static string hotFile = "hot";
+    public string hotFile = "hot";
 
     // The path to the build directory.
-    private static string? buildDirectory = "build";
+    public string? buildDirectory = "build";
 
     // The name of the manifest file.
-    private static string manifestFilename = "manifest.json";
+    public string manifestFilename = "manifest.json";
 
     // The path to the public directory.
-    private static string publicDirectory = "wwwroot";
+    public string publicDirectory = "wwwroot";
 
-    // Set the filename for the manifest file.
-    public static string? useManifestFilename(string newManifestFilename)
+    public static ViteBuilder? instance = null;
+    public static ViteBuilder Instance
     {
-        manifestFilename = newManifestFilename;
-        return null;
-    }
-
-    // Set the Vite "hot" file path.
-    public static string? useHotFile(string newHotFile)
-    {
-        hotFile = newHotFile;
-        return null;
-    }
-
-    //  Set the Vite build directory.
-    public static string? useBuildDir(string? newBuildDirectory)
-    {
-        buildDirectory = newBuildDirectory;
-        return null;
-    }
-
-    //  Set the public directory.
-    public static string? usePublicDir(string newPublicDirectory)
-    {
-        publicDirectory = newPublicDirectory;
-        return null;
+        get
+        {
+            if (instance == null)
+            {
+                instance = new ViteBuilder();
+            }
+            return instance;
+        }
     }
 
     //  Get the public directory and build path.
-    private static string getPublicDir(string path)
+    protected string getPublicDir(string path)
     {
         var pieces = new List<string>();
-        pieces.Add(publicDirectory);
-        if (buildDirectory != null && buildDirectory != "")
+        pieces.Add(ViteBuilder.Instance.publicDirectory);
+        if (ViteBuilder.Instance.buildDirectory != null && ViteBuilder.Instance.buildDirectory != "")
         {
-            pieces.Add(buildDirectory);
+            pieces.Add(ViteBuilder.Instance.buildDirectory);
         }
         pieces.Add(path);
         return String.Join("/", pieces);
     }
 
-    public static HtmlString input(string path)
+    public HtmlString input(string path)
     {
         if (isRunningHot())
         {
@@ -115,7 +100,7 @@ public static class Vite
         return new HtmlString(html);
     }
 
-    private static string? makeModuleTag(string path)
+    protected string? makeModuleTag(string path)
     {
         var builder = new TagBuilder("script");
         builder.Attributes.Add("type", "module");
@@ -125,7 +110,7 @@ public static class Vite
     }
 
     // Generate an appropriate tag for the given URL in HMR mode.
-    private static string makeTag(string url)
+    protected string makeTag(string url)
     {
         if (isCssPath(url))
         {
@@ -137,7 +122,7 @@ public static class Vite
 
 
     // Generate a script tag for the given URL.
-    private static string makeScriptTag(string filePath)
+    protected string makeScriptTag(string filePath)
     {
         var builder = new TagBuilder("script");
         builder.Attributes.Add("type", "text/javascript");
@@ -146,7 +131,7 @@ public static class Vite
     }
 
     // Generate a stylesheet tag for the given URL in HMR mode.
-    private static string makeStylesheetTag(string filePath)
+    protected string makeStylesheetTag(string filePath)
     {
         var builder = new TagBuilder("link");
         builder.Attributes.Add("rel", "stylesheet");
@@ -155,13 +140,13 @@ public static class Vite
     }
 
     // Determine whether the given path is a CSS file.
-    private static bool isCssPath(string path)
+    protected bool isCssPath(string path)
     {
         return Regex.IsMatch(path, @".\.(css|less|sass|scss|styl|stylus|pcss|postcss)", RegexOptions.IgnoreCase);
     }
 
     // Generate React refresh runtime script.
-    public static HtmlString reactRefresh()
+    public HtmlString reactRefresh()
     {
 
         if (!isRunningHot())
@@ -186,7 +171,7 @@ public static class Vite
     }
 
     // Get the path to a given asset when running in HMR mode.
-    private static string hotAsset(string path)
+    protected string hotAsset(string path)
     {
         var hotFilePath = getPublicDir(hotFile);
         var hotContents = File.ReadAllText(hotFilePath);
@@ -196,7 +181,7 @@ public static class Vite
     }
 
     // Get the URL for an asset.
-    public static string asset(string path)
+    protected string asset(string path)
     {
         if (isRunningHot())
         {
@@ -212,16 +197,60 @@ public static class Vite
         return "/" + String.Join("/", pieces);
     }
 
-    private static bool isRunningHot()
+    protected bool isRunningHot()
     {
         return File.Exists(getPublicDir("hot"));
     }
 
-    private static string GetString(IHtmlContent content)
+    protected string GetString(IHtmlContent content)
     {
         var writer = new System.IO.StringWriter();
         content.WriteTo(writer, HtmlEncoder.Default);
         return writer.ToString();
+    }
+}
+
+public static class Vite
+{
+
+    // Set the filename for the manifest file.
+    public static string? useManifestFilename(string manifestFilename)
+    {
+        ViteBuilder.Instance.manifestFilename = manifestFilename;
+        return null;
+    }
+
+    // Set the Vite "hot" file path.
+    public static string? useHotFile(string hotFile)
+    {
+        ViteBuilder.Instance.hotFile = hotFile;
+        return null;
+    }
+
+    //  Set the Vite build directory.
+    public static string? useBuildDir(string? buildDirectory)
+    {
+        ViteBuilder.Instance.buildDirectory = buildDirectory;
+        return null;
+    }
+
+    //  Set the public directory.
+    public static string? usePublicDir(string publicDirectory)
+    {
+        ViteBuilder.Instance.publicDirectory = publicDirectory;
+        return null;
+    }
+
+    // Generate tag(s) for the given input path.
+    public static HtmlString input(string path)
+    {
+        return ViteBuilder.Instance.input(path);
+    }
+
+    // Generate React refresh runtime script.
+    public static HtmlString reactRefresh()
+    {
+        return ViteBuilder.Instance.reactRefresh();
     }
 }
 

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -2,6 +2,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using System.Text.RegularExpressions;
 
 namespace InertiaCore.Utils;
 
@@ -118,7 +119,7 @@ public static class Vite
 
     private static bool isCssPath(string path)
     {
-        return Regex.IsMatch(path, @"/\.(css|less|sass|scss|styl|stylus|pcss|postcss)+$/", RegexOptions.IgnoreCase);
+        return Regex.IsMatch(path, @".\.(css|less|sass|scss|styl|stylus|pcss|postcss)", RegexOptions.IgnoreCase);
     }
 
     private static string makeCssTag(string filePath)

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -1,0 +1,130 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace InertiaCore.Utils;
+
+public static class Vite
+{
+
+    private static string GetString(IHtmlContent content)
+    {
+        var writer = new System.IO.StringWriter();
+        content.WriteTo(writer, HtmlEncoder.Default);
+        return writer.ToString();
+    }
+
+    private static string publicDir(string path)
+    {
+        return "wwwroot/build/" + path;
+    }
+
+    public static HtmlString input(string path)
+    {
+        if (isRunningHot())
+        {
+            return new HtmlString(makeModuleTag(hotAsset("@vite/client")) + makeModuleTag(hotAsset(path)));
+        }
+
+        if (!File.Exists(publicDir("manifest.json")))
+        {
+            throw new Exception("Vite Manifest is missing. Run `npm run build` and try again.");
+        }
+
+        var manifest = File.ReadAllText(publicDir("manifest.json"));
+        var manifestJson = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(manifest);
+
+        if (manifestJson == null)
+        {
+            throw new Exception("Vite Manifest is invalid. Run `npm run build` and try again.");
+        }
+
+        if (!manifestJson.ContainsKey(path))
+        {
+            throw new Exception("Asset not found in manifest: " + path);
+        }
+
+        JsonElement obj = manifestJson[path];
+        var filePath = obj.GetProperty("file");
+
+        var builder = new TagBuilder("script");
+        builder.Attributes.Add("type", "text/javascript");
+
+        var physicalPath = publicDir(filePath.ToString());
+        if (File.Exists(physicalPath))
+        {
+            builder.InnerHtml.AppendHtml(File.ReadAllText(physicalPath));
+        }
+
+        var html = GetString(builder);
+
+        try
+        {
+            var css = obj.GetProperty("css");
+            foreach (JsonElement item in css.EnumerateArray())
+            {
+                var cssBuilder = new TagBuilder("style");
+                cssBuilder.Attributes.Add("type", "text/css");
+                cssBuilder.InnerHtml.AppendHtml(File.ReadAllText(publicDir(item.ToString())));
+                html = html + GetString(cssBuilder);
+            }
+        }
+        catch (Exception)
+        {
+
+        }
+
+        return new HtmlString(html);
+    }
+
+    private static string hotAsset(string path)
+    {
+        var hotfile = publicDir("hot");
+        var hotContents = File.ReadAllText(hotfile);
+
+        return hotContents + "/" + path;
+    }
+
+    private static bool isRunningHot()
+    {
+        return File.Exists(publicDir("hot"));
+    }
+
+    private static string? makeModuleTag(string path)
+    {
+        var builder = new TagBuilder("script");
+        builder.Attributes.Add("type", "module");
+
+
+        builder.Attributes.Add("src", path);
+
+        return new HtmlString(GetString(builder)).Value;
+    }
+
+
+    public static HtmlString reactRefresh()
+    {
+
+        if (!isRunningHot())
+        {
+            return new HtmlString("<!-- no hot -->");
+        }
+
+        var builder = new TagBuilder("script");
+        builder.Attributes.Add("type", "module");
+
+        var inner = String.Format(
+            "import RefreshRuntime from '{0}';", hotAsset("@react-refresh")) +
+            "RefreshRuntime.injectIntoGlobalHook(window);" +
+            "window.$RefreshReg$ = () => { };" +
+            "window.$RefreshSig$ = () => (type) => type;" +
+            "window.__vite_plugin_react_preamble_installed__ = true;";
+
+
+        builder.InnerHtml.AppendHtml(inner);
+
+        return new HtmlString(GetString(builder));
+    }
+}
+

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -106,7 +106,7 @@ internal class ViteBuilder : IViteBuilder
     }
 
     //  Get the public directory and build path.
-    protected string getPublicDir(string path)
+    protected string getPublicPathForFile(string path)
     {
         var pieces = new List<string>();
         pieces.Add(getPublicDirectory());
@@ -126,12 +126,12 @@ internal class ViteBuilder : IViteBuilder
             return new HtmlString(makeModuleTag(hotAsset("@vite/client")) + makeModuleTag(hotAsset(path)));
         }
 
-        if (!_fileSystem.File.Exists(getPublicDir(manifestFilename)))
+        if (!_fileSystem.File.Exists(getPublicPathForFile(manifestFilename)))
         {
             throw new Exception("Vite Manifest is missing. Run `npm run build` and try again.");
         }
 
-        var manifest = _fileSystem.File.ReadAllText(getPublicDir(manifestFilename));
+        var manifest = _fileSystem.File.ReadAllText(getPublicPathForFile(manifestFilename));
         var manifestJson = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(manifest);
 
         if (manifestJson == null)
@@ -244,7 +244,7 @@ internal class ViteBuilder : IViteBuilder
     // Get the path to a given asset when running in HMR mode.
     protected string hotAsset(string path)
     {
-        var hotFilePath = getPublicDir(hotFile);
+        var hotFilePath = getPublicPathForFile(hotFile);
         var hotContents = _fileSystem.File.ReadAllText(hotFilePath);
 
         return hotContents + "/" + path;
@@ -270,7 +270,7 @@ internal class ViteBuilder : IViteBuilder
 
     protected bool isRunningHot()
     {
-        return _fileSystem.File.Exists(getPublicDir("hot"));
+        return _fileSystem.File.Exists(getPublicPathForFile("hot"));
     }
 
     protected string GetString(IHtmlContent content)

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -10,18 +10,17 @@ public interface IViteBuilder
 {
 
     public HtmlString reactRefresh();
+
     public HtmlString input(string path);
 
     public IViteBuilder useHotFile(string hotFile);
 
     public IViteBuilder useBuildDirectory(string? buildDirectory);
 
-
     public IViteBuilder useManifestFilename(string manifestFilename);
 
     public IViteBuilder usePublicDirectory(string publicDirectory);
 }
-
 
 internal class ViteBuilder : IViteBuilder
 {
@@ -232,7 +231,6 @@ internal class ViteBuilder : IViteBuilder
             "window.$RefreshSig$ = () => (type) => type;" +
             "window.__vite_plugin_react_preamble_installed__ = true;";
 
-
         builder.InnerHtml.AppendHtml(inner);
 
         return new HtmlString(GetString(builder));
@@ -245,7 +243,6 @@ internal class ViteBuilder : IViteBuilder
         var hotContents = _fileSystem.File.ReadAllText(hotFilePath);
 
         return hotContents + "/" + path;
-
     }
 
     // Get the URL for an asset.
@@ -327,4 +324,3 @@ public static class Vite
         ViteBuilder.setInstance(instance);
     }
 }
-

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -236,7 +236,7 @@ internal class ViteBuilder : IViteBuilder
     // Get the path to a given asset when running in HMR mode.
     protected string hotAsset(string path)
     {
-        var hotFilePath = getPublicPathForFile(hotFile);
+        var hotFilePath = getPublicPathForFile(getHotFile());
         var hotContents = _fileSystem.File.ReadAllText(hotFilePath);
 
         return hotContents + "/" + path;
@@ -262,7 +262,7 @@ internal class ViteBuilder : IViteBuilder
 
     protected bool isRunningHot()
     {
-        return _fileSystem.File.Exists(getPublicPathForFile("hot"));
+        return _fileSystem.File.Exists(getPublicPathForFile(getHotFile()));
     }
 
     protected string GetString(IHtmlContent content)

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 namespace InertiaCore.Utils;
 
 
-class ViteBuilder
+public class ViteBuilder
 {
     // The path to the "hot" file.
     public string hotFile = "hot";
@@ -35,7 +35,7 @@ class ViteBuilder
     }
 
     //  Get the public directory and build path.
-    protected string getPublicDir(string path)
+    protected virtual string getPublicDir(string path)
     {
         var pieces = new List<string>();
         pieces.Add(ViteBuilder.Instance.publicDirectory);
@@ -54,12 +54,12 @@ class ViteBuilder
             return new HtmlString(makeModuleTag(hotAsset("@vite/client")) + makeModuleTag(hotAsset(path)));
         }
 
-        if (!File.Exists(getPublicDir(manifestFilename)))
+        if (!exists(getPublicDir(manifestFilename)))
         {
             throw new Exception("Vite Manifest is missing. Run `npm run build` and try again.");
         }
 
-        var manifest = File.ReadAllText(getPublicDir(manifestFilename));
+        var manifest = readFile(getPublicDir(manifestFilename));
         var manifestJson = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(manifest);
 
         if (manifestJson == null)
@@ -120,7 +120,6 @@ class ViteBuilder
         return makeScriptTag(url);
     }
 
-
     // Generate a script tag for the given URL.
     protected string makeScriptTag(string filePath)
     {
@@ -171,17 +170,17 @@ class ViteBuilder
     }
 
     // Get the path to a given asset when running in HMR mode.
-    protected string hotAsset(string path)
+    protected virtual string hotAsset(string path)
     {
         var hotFilePath = getPublicDir(hotFile);
-        var hotContents = File.ReadAllText(hotFilePath);
+        var hotContents = readFile(hotFilePath);
 
         return hotContents + "/" + path;
 
     }
 
     // Get the URL for an asset.
-    protected string asset(string path)
+    public string asset(string path)
     {
         if (isRunningHot())
         {
@@ -197,9 +196,19 @@ class ViteBuilder
         return "/" + String.Join("/", pieces);
     }
 
-    protected bool isRunningHot()
+    protected virtual bool isRunningHot()
     {
-        return File.Exists(getPublicDir("hot"));
+        return exists(getPublicDir("hot"));
+    }
+
+    protected virtual string readFile(string path)
+    {
+        return File.ReadAllText(path);
+    }
+
+    protected virtual bool exists(string path)
+    {
+        return File.Exists(path);
     }
 
     protected string GetString(IHtmlContent content)

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -78,10 +78,6 @@ internal class ViteBuilder : IViteBuilder
             return new HtmlString(MakeTag(filePath.ToString()));
         }
 
-        /// <remark>
-        /// Handle JS and CSS combo
-        /// </remark>
-
         var html = MakeTag(filePath.ToString());
 
         try
@@ -92,9 +88,7 @@ internal class ViteBuilder : IViteBuilder
         }
         catch (Exception)
         {
-            /// <remark>
-            /// ignored
-            /// </remark>
+            // ignored
         }
 
         return new HtmlString(html);

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -18,7 +18,7 @@ public interface IViteBuilder
 
     public string? getBuildDirectory();
 
-    public void useBuildDirectory(string buildDirectory);
+    public void useBuildDirectory(string? buildDirectory);
 
     public string getManifestFilename();
 

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -48,7 +48,7 @@ public static class Vite
         JsonElement obj = manifestJson[path];
         var filePath = obj.GetProperty("file");
 
-        if (filePath.ToString().EndsWith(".css"))
+        if (isCssPath(filePath.ToString()))
         {
 
             return new HtmlString(makeCssTag(filePath.ToString()));
@@ -71,6 +71,11 @@ public static class Vite
         }
 
         return new HtmlString(html);
+    }
+
+    private static bool isCssPath(string path)
+    {
+        return Regex.IsMatch(path, @"/\.(css|less|sass|scss|styl|stylus|pcss|postcss)+$/", RegexOptions.IgnoreCase);
     }
 
     private static string makeCssTag(string filePath)

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -39,13 +39,18 @@ internal class ViteBuilder : IViteBuilder
 
     private readonly IFileSystem _fileSystem;
 
-    private static ViteBuilder? instance = null;
-    public static ViteBuilder Instance
+    private static IViteBuilder? instance = null;
+    public static IViteBuilder Instance
     {
         get
         {
             return instance ??= new ViteBuilder(new FileSystem());
         }
+    }
+
+    public static void setInstance(IViteBuilder? newInstance)
+    {
+        instance = newInstance;
     }
 
     public ViteBuilder(IFileSystem fileSystem)
@@ -314,6 +319,12 @@ public static class Vite
     public static HtmlString reactRefresh()
     {
         return ViteBuilder.Instance.reactRefresh();
+    }
+
+    // Set the IViteBuilder instance.
+    public static void setInstance(IViteBuilder instance)
+    {
+        ViteBuilder.setInstance(instance);
     }
 }
 

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -27,7 +27,9 @@ internal class ViteBuilder : IViteBuilder
         _fileSystem = fileSystem;
     }
 
-    //  Get the public directory and build path.
+    /// <summary>
+    /// Get the public directory and build path.
+    /// </summary>
     private string GetPublicPathForFile(string path)
     {
         var pieces = new List<string> { _options.Value.PublicDirectory };
@@ -40,6 +42,9 @@ internal class ViteBuilder : IViteBuilder
         return string.Join("/", pieces);
     }
 
+    /// <summary>
+    /// Generates various tags from a given input file path.
+    /// </summary>
     public HtmlString Input(string path)
     {
         if (IsRunningHot())
@@ -73,7 +78,10 @@ internal class ViteBuilder : IViteBuilder
             return new HtmlString(MakeTag(filePath.ToString()));
         }
 
-        // Handle JS and CSS combo
+        /// <remark>
+        /// Handle JS and CSS combo
+        /// </remark>
+
         var html = MakeTag(filePath.ToString());
 
         try
@@ -84,12 +92,17 @@ internal class ViteBuilder : IViteBuilder
         }
         catch (Exception)
         {
-            // ignored
+            /// <remark>
+            /// ignored
+            /// </remark>
         }
 
         return new HtmlString(html);
     }
 
+    /// <summary>
+    /// Generate script tag with type="module"
+    /// </summary>
     private static string MakeModuleTag(string path)
     {
         var builder = new TagBuilder("script");
@@ -99,13 +112,17 @@ internal class ViteBuilder : IViteBuilder
         return new HtmlString(GetString(builder)).Value + "\n\t";
     }
 
-    // Generate an appropriate tag for the given URL in HMR mode.
+    /// <summary>
+    /// Generate an appropriate tag for the given URL in HMR mode.
+    /// </summary>
     private string MakeTag(string url)
     {
         return IsCssPath(url) ? MakeStylesheetTag(url) : MakeScriptTag(url);
     }
 
-    // Generate a script tag for the given URL.
+    /// <summary>
+    /// Generate a script tag for the given URL.
+    /// </summary>
     private string MakeScriptTag(string filePath)
     {
         var builder = new TagBuilder("script");
@@ -114,7 +131,9 @@ internal class ViteBuilder : IViteBuilder
         return GetString(builder) + "\n\t";
     }
 
-    // Generate a stylesheet tag for the given URL in HMR mode.
+    /// <summary>
+    /// Generate a stylesheet tag for the given URL in HMR mode.
+    /// </summary>
     private string MakeStylesheetTag(string filePath)
     {
         var builder = new TagBuilder("link");
@@ -123,13 +142,17 @@ internal class ViteBuilder : IViteBuilder
         return GetString(builder).Replace("></link>", " />") + "\n\t";
     }
 
-    // Determine whether the given path is a CSS file.
+    /// <summary>
+    /// Determine whether the given path is a CSS file.
+    /// </summary>
     private static bool IsCssPath(string path)
     {
         return Regex.IsMatch(path, @".\.(css|less|sass|scss|styl|stylus|pcss|postcss)", RegexOptions.IgnoreCase);
     }
 
-    // Generate React refresh runtime script.
+    /// <summary>
+    /// Generate React refresh runtime script.
+    /// </summary>
     public HtmlString ReactRefresh()
     {
         if (!IsRunningHot())
@@ -151,7 +174,9 @@ internal class ViteBuilder : IViteBuilder
         return new HtmlString(GetString(builder));
     }
 
-    // Get the path to a given asset when running in HMR mode.
+    /// <summary>
+    /// Get the URL to a given asset when running in HMR mode.
+    /// </summary>
     private string HotAsset(string path)
     {
         var hotFilePath = GetPublicPathForFile(_options.Value.HotFile);
@@ -160,7 +185,9 @@ internal class ViteBuilder : IViteBuilder
         return hotContents + "/" + path;
     }
 
-    // Get the URL for an asset.
+    /// <summary>
+    /// Get the URL for an asset.
+    /// </summary>
     private string Asset(string path)
     {
         if (IsRunningHot())
@@ -178,11 +205,17 @@ internal class ViteBuilder : IViteBuilder
         return "/" + string.Join("/", pieces);
     }
 
+    /// <summary>
+    /// Determine if Vite is running in HMR mode.
+    /// </summary>
     private bool IsRunningHot()
     {
         return _fileSystem.File.Exists(GetPublicPathForFile(_options.Value.HotFile));
     }
 
+    /// <summary>
+    /// Convert an IHtmlContent to a string.
+    /// </summary>
     private static string GetString(IHtmlContent content)
     {
         var writer = new StringWriter();
@@ -197,9 +230,13 @@ public static class Vite
 
     internal static void UseBuilder(IViteBuilder instance) => _instance = instance;
 
-    // Generate tag(s) for the given input path.
+    /// <summary>
+    /// Generates various tags from a given input file path.
+    /// </summary>
     public static HtmlString Input(string path) => _instance.Input(path);
 
-    // Generate React refresh runtime script.
+    /// <summary>
+    /// Generate React refresh runtime script.
+    /// </summary>
     public static HtmlString ReactRefresh() => _instance.ReactRefresh();
 }

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -12,21 +12,14 @@ public interface IViteBuilder
     public HtmlString reactRefresh();
     public HtmlString input(string path);
 
-    public string getHotFile();
+    public IViteBuilder useHotFile(string hotFile);
 
-    public void useHotFile(string hotFile);
+    public IViteBuilder useBuildDirectory(string? buildDirectory);
 
-    public string? getBuildDirectory();
 
-    public void useBuildDirectory(string? buildDirectory);
+    public IViteBuilder useManifestFilename(string manifestFilename);
 
-    public string getManifestFilename();
-
-    public void useManifestFilename(string manifestFilename);
-
-    public string getPublicDirectory();
-
-    public void usePublicDirectory(string publicDirectory);
+    public IViteBuilder usePublicDirectory(string publicDirectory);
 }
 
 
@@ -65,9 +58,10 @@ internal class ViteBuilder : IViteBuilder
         return this.hotFile;
     }
 
-    public void useHotFile(string hotFile)
+    public IViteBuilder useHotFile(string hotFile)
     {
         this.hotFile = hotFile;
+        return this;
     }
 
     public string? getBuildDirectory()
@@ -75,9 +69,10 @@ internal class ViteBuilder : IViteBuilder
         return this.buildDirectory;
     }
 
-    public void useBuildDirectory(string? buildDirectory)
+    public IViteBuilder useBuildDirectory(string? buildDirectory)
     {
         this.buildDirectory = buildDirectory;
+        return this;
     }
 
     public string getManifestFilename()
@@ -85,9 +80,10 @@ internal class ViteBuilder : IViteBuilder
         return this.manifestFilename;
     }
 
-    public void useManifestFilename(string manifestFilename)
+    public IViteBuilder useManifestFilename(string manifestFilename)
     {
         this.manifestFilename = manifestFilename;
+        return this;
     }
 
     public string getPublicDirectory()
@@ -95,9 +91,10 @@ internal class ViteBuilder : IViteBuilder
         return this.publicDirectory;
     }
 
-    public void usePublicDirectory(string publicDirectory)
+    public IViteBuilder usePublicDirectory(string publicDirectory)
     {
         this.publicDirectory = publicDirectory;
+        return this;
     }
 
     //  Get the public directory and build path.
@@ -280,31 +277,31 @@ public static class Vite
 {
 
     // Set the filename for the manifest file.
-    public static string? useManifestFilename(string manifestFilename)
+    public static IViteBuilder? useManifestFilename(string manifestFilename)
     {
-        ViteBuilder.Instance.manifestFilename = manifestFilename;
-        return null;
+        ViteBuilder.Instance.useManifestFilename(manifestFilename);
+        return ViteBuilder.Instance;
     }
 
     // Set the Vite "hot" file path.
-    public static string? useHotFile(string hotFile)
+    public static IViteBuilder useHotFile(string hotFile)
     {
-        ViteBuilder.Instance.hotFile = hotFile;
-        return null;
+        ViteBuilder.Instance.useHotFile(hotFile);
+        return ViteBuilder.Instance;
     }
 
     //  Set the Vite build directory.
-    public static string? useBuildDir(string? buildDirectory)
+    public static IViteBuilder useBuildDir(string? buildDirectory)
     {
-        ViteBuilder.Instance.buildDirectory = buildDirectory;
-        return null;
+        ViteBuilder.Instance.useBuildDirectory(buildDirectory);
+        return ViteBuilder.Instance;
     }
 
     //  Set the public directory.
-    public static string? usePublicDir(string publicDirectory)
+    public static IViteBuilder usePublicDir(string publicDirectory)
     {
-        ViteBuilder.Instance.publicDirectory = publicDirectory;
-        return null;
+        ViteBuilder.Instance.usePublicDirectory(publicDirectory);
+        return ViteBuilder.Instance;
     }
 
     // Generate tag(s) for the given input path.

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -75,11 +75,6 @@ internal class ViteBuilder : IViteBuilder
         return this.buildDirectory;
     }
 
-    public string getCurrentDirectory()
-    {
-        return this._fileSystem.Directory.GetCurrentDirectory();
-    }
-
     public void useBuildDirectory(string? buildDirectory)
     {
         this.buildDirectory = buildDirectory;

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -48,6 +48,41 @@ public static class Vite
         JsonElement obj = manifestJson[path];
         var filePath = obj.GetProperty("file");
 
+        if (filePath.ToString().EndsWith(".css"))
+        {
+
+            return new HtmlString(makeCssTag(filePath.ToString()));
+        }
+
+        // Handle JS and CSS combo
+        var html = makeJsTag(filePath.ToString());
+
+        try
+        {
+            var css = obj.GetProperty("css");
+            foreach (JsonElement item in css.EnumerateArray())
+            {
+                html = html + makeCssTag(item.ToString());
+            }
+        }
+        catch (Exception)
+        {
+
+        }
+
+        return new HtmlString(html);
+    }
+
+    private static string makeCssTag(string filePath)
+    {
+        var builder = new TagBuilder("style");
+        builder.Attributes.Add("type", "text/css");
+        builder.InnerHtml.AppendHtml(File.ReadAllText(publicDir(filePath)));
+        return GetString(builder);
+    }
+
+    private static string makeJsTag(string filePath)
+    {
         var builder = new TagBuilder("script");
         builder.Attributes.Add("type", "text/javascript");
 
@@ -57,25 +92,7 @@ public static class Vite
             builder.InnerHtml.AppendHtml(File.ReadAllText(physicalPath));
         }
 
-        var html = GetString(builder);
-
-        try
-        {
-            var css = obj.GetProperty("css");
-            foreach (JsonElement item in css.EnumerateArray())
-            {
-                var cssBuilder = new TagBuilder("style");
-                cssBuilder.Attributes.Add("type", "text/css");
-                cssBuilder.InnerHtml.AppendHtml(File.ReadAllText(publicDir(item.ToString())));
-                html = html + GetString(cssBuilder);
-            }
-        }
-        catch (Exception)
-        {
-
-        }
-
-        return new HtmlString(html);
+        return GetString(builder);
     }
 
     private static string hotAsset(string path)

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -109,10 +109,11 @@ internal class ViteBuilder : IViteBuilder
     protected string getPublicDir(string path)
     {
         var pieces = new List<string>();
-        pieces.Add(ViteBuilder.Instance.publicDirectory);
-        if (ViteBuilder.Instance.buildDirectory != null && ViteBuilder.Instance.buildDirectory != "")
+        pieces.Add(getPublicDirectory());
+        var buildDirectory = getBuildDirectory();
+        if (buildDirectory != null && buildDirectory != "")
         {
-            pieces.Add(ViteBuilder.Instance.buildDirectory);
+            pieces.Add(buildDirectory);
         }
         pieces.Add(path);
         return String.Join("/", pieces);

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -6,20 +6,43 @@ using System.Text.RegularExpressions;
 using System.IO.Abstractions;
 namespace InertiaCore.Utils;
 
+public interface IViteBuilder
+{
 
-public class ViteBuilder
+    public HtmlString reactRefresh();
+    public HtmlString input(string path);
+
+    public string getHotFile();
+
+    public void useHotFile(string hotFile);
+
+    public string? getBuildDirectory();
+
+    public void useBuildDirectory(string buildDirectory);
+
+    public string getManifestFilename();
+
+    public void useManifestFilename(string manifestFilename);
+
+    public string getPublicDirectory();
+
+    public void usePublicDirectory(string publicDirectory);
+}
+
+
+internal class ViteBuilder : IViteBuilder
 {
     // The path to the "hot" file.
-    public string hotFile = "hot";
+    protected string hotFile = "hot";
 
     // The path to the build directory.
-    public string? buildDirectory = "build";
+    protected string? buildDirectory = "build";
 
     // The name of the manifest file.
-    public string manifestFilename = "manifest.json";
+    protected string manifestFilename = "manifest.json";
 
     // The path to the public directory.
-    public string publicDirectory = "wwwroot";
+    protected string publicDirectory = "wwwroot";
 
     private readonly IFileSystem _fileSystem;
 
@@ -35,6 +58,51 @@ public class ViteBuilder
     public ViteBuilder(IFileSystem fileSystem)
     {
         this._fileSystem = fileSystem;
+    }
+
+    public string getHotFile()
+    {
+        return this.hotFile;
+    }
+
+    public void useHotFile(string hotFile)
+    {
+        this.hotFile = hotFile;
+    }
+
+    public string? getBuildDirectory()
+    {
+        return this.buildDirectory;
+    }
+
+    public string getCurrentDirectory()
+    {
+        return this._fileSystem.Directory.GetCurrentDirectory();
+    }
+
+    public void useBuildDirectory(string? buildDirectory)
+    {
+        this.buildDirectory = buildDirectory;
+    }
+
+    public string getManifestFilename()
+    {
+        return this.manifestFilename;
+    }
+
+    public void useManifestFilename(string manifestFilename)
+    {
+        this.manifestFilename = manifestFilename;
+    }
+
+    public string getPublicDirectory()
+    {
+        return this.publicDirectory;
+    }
+
+    public void usePublicDirectory(string publicDirectory)
+    {
+        this.publicDirectory = publicDirectory;
     }
 
     //  Get the public directory and build path.

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -8,16 +8,59 @@ namespace InertiaCore.Utils;
 public static class Vite
 {
 
-    private static string GetString(IHtmlContent content)
+    // The path to the "hot" file.
+    private static string hotFile = "hot";
+
+    // The path to the build directory.
+    private static string? buildDirectory = "build";
+
+    // The name of the manifest file.
+    private static string manifestFilename = "manifest.json";
+
+    // The path to the public directory.
+    private static string publicDirectory = "wwwroot";
+    public static string GetString(IHtmlContent content)
     {
         var writer = new System.IO.StringWriter();
         content.WriteTo(writer, HtmlEncoder.Default);
         return writer.ToString();
     }
 
-    private static string publicDir(string path)
+    // Set the filename for the manifest file.
+    public static string useManifestFilename(string newManifestFilename)
     {
-        return "wwwroot/build/" + path;
+        return manifestFilename = newManifestFilename;
+    }
+
+    // Set the Vite "hot" file path.
+    public static string useHotFile(string newHotFile)
+    {
+        return hotFile = newHotFile;
+    }
+
+    //  Set the Vite build directory.
+    public static string? useBuildDir(string? newBuildDirectory)
+    {
+        return buildDirectory = newBuildDirectory;
+    }
+
+    //  Set the public directory.
+    public static string usePublicDir(string newPublicDirectory)
+    {
+        return publicDirectory = newPublicDirectory;
+    }
+
+    //  Get the public directory and build path.
+    private static string getPublicDir(string path)
+    {
+        var pieces = new List<string>();
+        pieces.Add(publicDirectory);
+        if (buildDirectory != null && buildDirectory != "")
+        {
+            pieces.Add(buildDirectory);
+        }
+        pieces.Add(path);
+        return String.Join("/", pieces);
     }
 
     public static HtmlString input(string path)
@@ -27,12 +70,12 @@ public static class Vite
             return new HtmlString(makeModuleTag(hotAsset("@vite/client")) + makeModuleTag(hotAsset(path)));
         }
 
-        if (!File.Exists(publicDir("manifest.json")))
+        if (!File.Exists(getPublicDir(manifestFilename)))
         {
             throw new Exception("Vite Manifest is missing. Run `npm run build` and try again.");
         }
 
-        var manifest = File.ReadAllText(publicDir("manifest.json"));
+        var manifest = File.ReadAllText(getPublicDir(manifestFilename));
         var manifestJson = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(manifest);
 
         if (manifestJson == null)

--- a/InertiaCoreTests/InertiaCoreTests.csproj
+++ b/InertiaCoreTests/InertiaCoreTests.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
         <PackageReference Include="NUnit.Analyzers" Version="3.3.0"/>
         <PackageReference Include="coverlet.collector" Version="3.1.2"/>
+        <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="19.2.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/InertiaCoreTests/UnitTestVite.cs
+++ b/InertiaCoreTests/UnitTestVite.cs
@@ -32,6 +32,7 @@ public partial class Tests
     }
 
     [Test]
+    [Description("Test if the Vite Helper handles hot module reloading properly.")]
     public void TestHot()
     {
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -57,6 +58,7 @@ public partial class Tests
     }
 
     [Test]
+    [Description("Test if the Vite Helper handles HMR disabled properly.")]
     public void TestNotHot()
     {
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
@@ -70,6 +72,7 @@ public partial class Tests
     }
 
     [Test]
+    [Description("Test if the Vite Helper handles generating HTML tags for both JS and CSS from HMR and the manifest properly.")]
     public void TestViteInput()
     {
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
@@ -168,6 +171,7 @@ public partial class Tests
     }
 
     [Test]
+    [Description("Test if the Vite Facade behaves correctly with different builder configurations.")]
     public void TestViteFacade()
     {
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());

--- a/InertiaCoreTests/UnitTestVite.cs
+++ b/InertiaCoreTests/UnitTestVite.cs
@@ -1,11 +1,35 @@
 using System.IO.Abstractions.TestingHelpers;
+using InertiaCore.Extensions;
+using InertiaCore.Models;
 using InertiaCore.Utils;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace InertiaCoreTests;
 
 public partial class Tests
 {
+    [Test]
+    [Description("Test if the Vite configuration registers properly the service.")]
+    public void TestViteConfiguration()
+    {
+        Assert.Throws<NullReferenceException>(() => Vite.ReactRefresh());
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddInertia();
+
+        Assert.Multiple(() =>
+        {
+            Assert.DoesNotThrow(() => builder.Services.AddViteHelper());
+            Assert.That(builder.Services.Any(s => s.ServiceType == typeof(IViteBuilder)), Is.True);
+        });
+
+        var app = builder.Build();
+        Assert.DoesNotThrow(() => app.UseInertia());
+
+        Assert.DoesNotThrow(() => Vite.ReactRefresh());
+    }
 
     [Test]
     public void TestHot()
@@ -14,17 +38,16 @@ public partial class Tests
         {
             { @"/wwwroot/build/hot", new MockFileData("http://127.0.0.1:5174") },
         });
+        var options = new Mock<IOptions<ViteOptions>>();
+        options.SetupGet(x => x.Value).Returns(new ViteOptions());
 
-        var mock = new Mock<ViteBuilder>(fileSystem);
+        var mock = new Mock<ViteBuilder>(options.Object);
+        mock.Object.UseFileSystem(fileSystem);
 
-        var htmlResult = mock.Object.reactRefresh();
-        mock.Object.usePublicDirectory(@"wwwroot");
+        var htmlResult = mock.Object.ReactRefresh();
 
-        Assert.That(htmlResult.ToString(), Is.Not.EqualTo("<!-- no hot -->"));
-
-        htmlResult = mock.Object.reactRefresh();
-
-        var inner = "<script type=\"module\">import RefreshRuntime from 'http://127.0.0.1:5174/@react-refresh';" +
+        const string inner =
+            "<script type=\"module\">import RefreshRuntime from 'http://127.0.0.1:5174/@react-refresh';" +
             "RefreshRuntime.injectIntoGlobalHook(window);" +
             "window.$RefreshReg$ = () => { };" +
             "window.$RefreshSig$ = () => (type) => type;" +
@@ -36,137 +59,150 @@ public partial class Tests
     [Test]
     public void TestNotHot()
     {
-        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData> { });
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+        var options = new Mock<IOptions<ViteOptions>>();
+        options.SetupGet(x => x.Value).Returns(new ViteOptions());
 
-        var mock = new Mock<ViteBuilder>(fileSystem);
+        var mock = new Mock<ViteBuilder>(options.Object);
+        mock.Object.UseFileSystem(fileSystem);
 
-        var htmlResult = mock.Object.reactRefresh();
-
-        Assert.That(htmlResult.ToString(), Is.EqualTo("<!-- no hot -->"));
-
-        Assert.That(Vite.reactRefresh().ToString(), Is.EqualTo("<!-- no hot -->"));
-    }
-
-    [Test]
-    public void TestProperties()
-    {
-        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData> { });
-
-        var mock = new Mock<ViteBuilder>(fileSystem);
-
-        mock.Object.useBuildDirectory("build2");
-
-        Assert.That(mock.Object.getBuildDirectory(), Is.EqualTo("build2"));
-
-        mock.Object.usePublicDirectory("public");
-
-        Assert.That(mock.Object.getPublicDirectory(), Is.EqualTo("public"));
-
-        mock.Object.useManifestFilename("test.json");
-
-        Assert.That(mock.Object.getManifestFilename(), Is.EqualTo("test.json"));
-
-        mock.Object.useHotFile("cold");
-
-        Assert.That(mock.Object.getHotFile(), Is.EqualTo("cold"));
+        Assert.That(mock.Object.ReactRefresh().ToString(), Is.EqualTo("<!-- no hot -->"));
     }
 
     [Test]
     public void TestViteInput()
     {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+        var options = new Mock<IOptions<ViteOptions>>();
+        options.SetupGet(x => x.Value).Returns(new ViteOptions());
 
-        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData> { });
-        var mock = new Mock<ViteBuilder>(fileSystem);
+        var mock = new Mock<ViteBuilder>(options.Object);
+        mock.Object.UseFileSystem(fileSystem);
 
         // Missing manifest exception
-        Assert.Throws<Exception>(() => mock.Object.input("app.tsx"));
+        Assert.Throws<Exception>(() => mock.Object.Input("app.tsx"));
 
         fileSystem.AddFile(@"/wwwroot/build/manifest.json", new MockFileData("null"));
 
         // Null manifest exception
-        Assert.Throws<Exception>(() => mock.Object.input("app.tsx"));
+        Assert.Throws<Exception>(() => mock.Object.Input("app.tsx"));
 
         // Missing info exception
         fileSystem.AddFile(@"/wwwroot/build/manifest.json", new MockFileData("{\"main.tsx\": {}}"));
 
-        Assert.Throws<Exception>(() => mock.Object.input("app.tsx"));
+        Assert.Throws<Exception>(() => mock.Object.Input("app.tsx"));
 
         // Basic JS File
-        fileSystem.AddFile(@"/wwwroot/build/manifest.json", new MockFileData("{\"app.tsx\": {\"file\": \"assets/main-19038c6a.js\"}}"));
+        fileSystem.AddFile(@"/wwwroot/build/manifest.json",
+            new MockFileData("{\"app.tsx\": {\"file\": \"assets/main-19038c6a.js\"}}"));
 
-        var result = mock.Object.input("app.tsx");
-        Assert.That(result.ToString(), Is.EqualTo("<script src=\"/build/assets/main-19038c6a.js\" type=\"text/javascript\"></script>\n\t"));
+        var result = mock.Object.Input("app.tsx");
+        Assert.That(result.ToString(),
+            Is.EqualTo("<script src=\"/build/assets/main-19038c6a.js\" type=\"text/javascript\"></script>\n\t"));
 
         // Basic JS File with CSS import
-        fileSystem.AddFile(@"/wwwroot/build/manifest.json", new MockFileData("{\"app.tsx\": {\"file\": \"assets/main.js\",\"css\": [\"assets/index.css\"]}}"));
+        fileSystem.AddFile(@"/wwwroot/build/manifest.json",
+            new MockFileData("{\"app.tsx\": {\"file\": \"assets/main.js\",\"css\": [\"assets/index.css\"]}}"));
 
-        result = mock.Object.input("app.tsx");
-        Assert.That(result.ToString(), Is.EqualTo("<script src=\"/build/assets/main.js\" type=\"text/javascript\"></script>\n\t<link href=\"/build/assets/index.css\" rel=\"stylesheet\" />\n\t"));
+        result = mock.Object.Input("app.tsx");
+        Assert.That(result.ToString(),
+            Is.EqualTo(
+                "<script src=\"/build/assets/main.js\" type=\"text/javascript\"></script>\n\t<link href=\"/build/assets/index.css\" rel=\"stylesheet\" />\n\t"));
 
         // Basic CSS file
-        fileSystem.AddFile(@"/wwwroot/build/manifest.json", new MockFileData("{\"index.scss\": {\"file\": \"assets/index.css\"}}"));
+        fileSystem.AddFile(@"/wwwroot/build/manifest.json",
+            new MockFileData("{\"index.scss\": {\"file\": \"assets/index.css\"}}"));
 
-        result = mock.Object.input("index.scss");
+        result = mock.Object.Input("index.scss");
         Assert.That(result.ToString(), Is.EqualTo("<link href=\"/build/assets/index.css\" rel=\"stylesheet\" />\n\t"));
 
         // Basic CSS file with custom builder dir
-        fileSystem.AddFile(@"/wwwroot/manifest.json", new MockFileData("{\"index.scss\": {\"file\": \"assets/index.css\"}}"));
-        mock.Object.useBuildDirectory(null);
-        result = mock.Object.input("index.scss");
+        fileSystem.AddFile(@"/wwwroot/manifest.json",
+            new MockFileData("{\"index.scss\": {\"file\": \"assets/index.css\"}}"));
+        options.SetupGet(x => x.Value).Returns(new ViteOptions
+        {
+            BuildDirectory = null
+        });
+        result = mock.Object.Input("index.scss");
         Assert.That(result.ToString(), Is.EqualTo("<link href=\"/assets/index.css\" rel=\"stylesheet\" />\n\t"));
 
 
         // Hot file with css import
-        mock.Object.useBuildDirectory("build");
+        options.SetupGet(x => x.Value).Returns(new ViteOptions
+        {
+            BuildDirectory = "build"
+        });
         fileSystem.AddFile(@"/wwwroot/build/hot", new MockFileData("http://127.0.0.1:5174"));
 
-        result = mock.Object.input("index.scss");
-        Assert.That(result.ToString(), Is.EqualTo("<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
-           "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t"));
+        result = mock.Object.Input("index.scss");
+        Assert.That(result.ToString(), Is.EqualTo(
+            "<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
+            "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t"));
 
         // Test null build directory
         fileSystem.AddFile(@"/wwwroot/hot", new MockFileData("http://127.0.0.1:5174"));
-        mock.Object.useBuildDirectory(null);
-        result = mock.Object.input("index.scss");
-        Assert.That(result.ToString(), Is.EqualTo("<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
-           "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t"));
+        options.SetupGet(x => x.Value).Returns(new ViteOptions
+        {
+            BuildDirectory = null
+        });
+        result = mock.Object.Input("index.scss");
+        Assert.That(result.ToString(), Is.EqualTo(
+            "<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
+            "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t"));
 
         // Test empty build directory
-        mock.Object.useBuildDirectory("");
-        result = mock.Object.input("index.scss");
-        Assert.That(result.ToString(), Is.EqualTo("<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
-           "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t"));
+        options.SetupGet(x => x.Value).Returns(new ViteOptions
+        {
+            BuildDirectory = ""
+        });
+        result = mock.Object.Input("index.scss");
+        Assert.That(result.ToString(), Is.EqualTo(
+            "<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
+            "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t"));
 
         // Basic JS File via hot
-        result = mock.Object.input("app.tsx");
-        Assert.That(result.ToString(), Is.EqualTo("<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
+        result = mock.Object.Input("app.tsx");
+        Assert.That(result.ToString(), Is.EqualTo(
+            "<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
             "<script src=\"http://127.0.0.1:5174/app.tsx\" type=\"module\"></script>\n\t"));
     }
 
     [Test]
     public void TestViteFacade()
     {
-        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData> { });
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+        var options = new Mock<IOptions<ViteOptions>>();
+        options.SetupGet(x => x.Value).Returns(new ViteOptions
+        {
+            BuildDirectory = "build2",
+            ManifestFilename = "manifest-test.json",
+            HotFile = "cold",
+            PublicDirectory = "public"
+        });
 
-        var mock = new Mock<ViteBuilder>(fileSystem);
+        var mock = new Mock<ViteBuilder>(options.Object);
+        mock.Object.UseFileSystem(fileSystem);
 
-        Vite.setInstance(mock.Object);
-
-        Vite.useBuildDir("build2");
-        Vite.useManifestFilename("manifest-test.json");
-        Vite.useHotFile("cold");
-        Vite.usePublicDir("public");
+        Vite.UseBuilder(mock.Object);
 
         // Basic Manifest with CSS file
-        fileSystem.AddFile(@"/public/build2/manifest-test.json", new MockFileData("{\"index.scss\": {\"file\": \"assets/index.css\"}}"));
-        var result = Vite.input("index.scss");
+        fileSystem.AddFile(@"/public/build2/manifest-test.json",
+            new MockFileData("{\"index.scss\": {\"file\": \"assets/index.css\"}}"));
+        var result = Vite.Input("index.scss");
         Assert.That(result.ToString(), Is.EqualTo("<link href=\"/build2/assets/index.css\" rel=\"stylesheet\" />\n\t"));
 
         // Hot file with css import
-        Vite.useBuildDir(null);
+        options.SetupGet(x => x.Value).Returns(new ViteOptions
+        {
+            BuildDirectory = null,
+            ManifestFilename = "manifest-test.json",
+            HotFile = "cold",
+            PublicDirectory = "public"
+        });
         fileSystem.AddFile(@"/public/cold", new MockFileData("http://127.0.0.1:5174"));
-        result = Vite.input("index.scss");
-        Assert.That(result.ToString(), Is.EqualTo("<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
-           "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t"));
+        result = Vite.Input("index.scss");
+        Assert.That(result.ToString(), Is.EqualTo(
+            "<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
+            "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t"));
     }
 }

--- a/InertiaCoreTests/UnitTestVite.cs
+++ b/InertiaCoreTests/UnitTestVite.cs
@@ -1,0 +1,161 @@
+using InertiaCore.Utils;
+using Moq;
+using Moq.Protected;
+
+namespace InertiaCoreTests;
+
+public partial class Tests : ViteBuilder
+{
+
+    [Test]
+    public void TestHot()
+    {
+
+        var mock = new Mock<ViteBuilder>();
+
+        var htmlResult = mock.Object.reactRefresh();
+
+        Assert.AreEqual(htmlResult.ToString(), "<!-- no hot -->");
+
+        Assert.AreEqual(Vite.reactRefresh().ToString(), "<!-- no hot -->");
+
+        mock.Protected()
+            .Setup<bool>("isRunningHot")
+            .Returns(true);
+
+        mock.Protected()
+            .Setup<string>("hotAsset", ItExpr.IsAny<string>())
+            .Returns((string path) => { return "http://127.0.0.1:5174/" + path; });
+
+        htmlResult = mock.Object.reactRefresh();
+
+        var inner = "<script type=\"module\">import RefreshRuntime from 'http://127.0.0.1:5174/@react-refresh';" +
+            "RefreshRuntime.injectIntoGlobalHook(window);" +
+            "window.$RefreshReg$ = () => { };" +
+            "window.$RefreshSig$ = () => (type) => type;" +
+            "window.__vite_plugin_react_preamble_installed__ = true;</script>";
+
+        Assert.AreEqual(htmlResult.ToString(), inner);
+    }
+
+    [Test]
+    public void TestViteFacade()
+    {
+
+        Vite.useBuildDir("build2");
+
+        Assert.AreEqual(ViteBuilder.Instance.buildDirectory, "build2");
+
+        Vite.useManifestFilename("manifest-test.json");
+
+        Assert.AreEqual(ViteBuilder.Instance.manifestFilename, "manifest-test.json");
+
+        Vite.useHotFile("cold");
+
+        Assert.AreEqual(ViteBuilder.Instance.hotFile, "cold");
+
+        Vite.usePublicDir("public");
+
+        Assert.AreEqual(ViteBuilder.Instance.publicDirectory, "public");
+
+        Assert.True(GetPublicDir("file.css") == "public/build2/file.css");
+
+        Vite.useBuildDir(null);
+
+        Assert.True(GetPublicDir("file.css") == "public/file.css");
+
+        Vite.useBuildDir("");
+
+        Assert.True(GetPublicDir("file.css") == "public/file.css");
+    }
+
+    [Test]
+    public void TestViteBuilderHelpers()
+    {
+
+        var mock = new Mock<ViteBuilder>();
+
+        mock.Protected()
+            .Setup<bool>("isRunningHot")
+            .Returns(false);
+
+        Assert.AreEqual(mock.Object.asset("manifest.json"), "/build/manifest.json");
+
+        mock.Object.buildDirectory = null;
+
+        Assert.AreEqual(mock.Object.asset("manifest.json"), "/manifest.json");
+
+        mock.Protected()
+            .Setup<bool>("isRunningHot")
+            .Returns(true);
+
+        mock.Protected()
+            .Setup<string>("readFile", ItExpr.IsAny<string>())
+            .Returns("http://127.0.0.1:5174");
+
+        Assert.AreEqual(mock.Object.asset("manifest.json"), null);
+    }
+
+    [Test]
+    public void TestViteInput()
+    {
+
+        var mock = new Mock<ViteBuilder>();
+
+        Assert.Throws<Exception>(() => mock.Object.input("app.tsx"));
+
+        mock.Protected()
+            .Setup<bool>("exists", ItExpr.IsAny<string>())
+            .Returns(true);
+
+        mock.Protected()
+            .Setup<string>("readFile", ItExpr.IsAny<string>())
+            .Returns("null");
+
+        Assert.Throws<Exception>(() => mock.Object.input("app.tsx"));
+
+        mock.Protected()
+            .Setup<string>("readFile", ItExpr.IsAny<string>())
+            .Returns("{\"main.tsx\": {}}");
+
+        Assert.Throws<Exception>(() => mock.Object.input("app.tsx"));
+
+        mock.Protected()
+            .Setup<string>("readFile", ItExpr.IsAny<string>())
+            .Returns("{\"app.tsx\": {\"file\": \"assets/main-19038c6a.js\"}}");
+
+        var result = mock.Object.input("app.tsx");
+        Assert.AreEqual(result.ToString(), "<script src=\"/build/assets/main-19038c6a.js\" type=\"text/javascript\"></script>\n\t");
+
+        mock.Protected()
+            .Setup<string>("readFile", ItExpr.IsAny<string>())
+            .Returns("{\"app.tsx\": {\"file\": \"assets/main.js\",\"css\": [\"assets/index.css\"]}}");
+
+        result = mock.Object.input("app.tsx");
+        Assert.AreEqual(result.ToString(), "<script src=\"/build/assets/main.js\" type=\"text/javascript\"></script>\n\t<link href=\"/build/assets/index.css\" rel=\"stylesheet\" />\n\t");
+
+        mock.Protected()
+            .Setup<string>("readFile", ItExpr.IsAny<string>())
+            .Returns("{\"index.scss\": {\"file\": \"assets/index.css\"}}");
+
+        result = mock.Object.input("index.scss");
+        Assert.AreEqual(result.ToString(), "<link href=\"/build/assets/index.css\" rel=\"stylesheet\" />\n\t");
+
+        mock.Protected()
+            .Setup<bool>("isRunningHot")
+            .Returns(true);
+
+        mock.Protected()
+            .Setup<string>("hotAsset", ItExpr.IsAny<string>())
+            .Returns((string path) => { return "http://127.0.0.1:5174/" + path; });
+
+        result = mock.Object.input("index.scss");
+        Assert.AreEqual(result.ToString(), "<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
+            "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t");
+    }
+
+    public string GetPublicDir(string path)
+    {
+        return base.getPublicDir(path);
+    }
+}

--- a/InertiaCoreTests/UnitTestVite.cs
+++ b/InertiaCoreTests/UnitTestVite.cs
@@ -30,7 +30,7 @@ public partial class Tests
             "window.$RefreshSig$ = () => (type) => type;" +
             "window.__vite_plugin_react_preamble_installed__ = true;</script>";
 
-        Assert.AreEqual(htmlResult.ToString(), inner);
+        Assert.That(htmlResult.ToString(), Is.EqualTo(inner));
     }
 
     [Test]
@@ -71,26 +71,26 @@ public partial class Tests
         fileSystem.AddFile(@"/wwwroot/build/manifest.json", new MockFileData("{\"app.tsx\": {\"file\": \"assets/main-19038c6a.js\"}}"));
 
         var result = mock.Object.input("app.tsx");
-        Assert.AreEqual(result.ToString(), "<script src=\"/build/assets/main-19038c6a.js\" type=\"text/javascript\"></script>\n\t");
+        Assert.That(result.ToString(), Is.EqualTo("<script src=\"/build/assets/main-19038c6a.js\" type=\"text/javascript\"></script>\n\t"));
 
         // Basic JS File with CSS import
         fileSystem.AddFile(@"/wwwroot/build/manifest.json", new MockFileData("{\"app.tsx\": {\"file\": \"assets/main.js\",\"css\": [\"assets/index.css\"]}}"));
 
         result = mock.Object.input("app.tsx");
-        Assert.AreEqual(result.ToString(), "<script src=\"/build/assets/main.js\" type=\"text/javascript\"></script>\n\t<link href=\"/build/assets/index.css\" rel=\"stylesheet\" />\n\t");
+        Assert.That(result.ToString(), Is.EqualTo("<script src=\"/build/assets/main.js\" type=\"text/javascript\"></script>\n\t<link href=\"/build/assets/index.css\" rel=\"stylesheet\" />\n\t"));
 
         // Basic CSS file
         fileSystem.AddFile(@"/wwwroot/build/manifest.json", new MockFileData("{\"index.scss\": {\"file\": \"assets/index.css\"}}"));
 
         result = mock.Object.input("index.scss");
-        Assert.AreEqual(result.ToString(), "<link href=\"/build/assets/index.css\" rel=\"stylesheet\" />\n\t");
+        Assert.That(result.ToString(), Is.EqualTo("<link href=\"/build/assets/index.css\" rel=\"stylesheet\" />\n\t"));
 
         // Hot file with css import
         fileSystem.AddFile(@"/wwwroot/build/hot", new MockFileData("http://127.0.0.1:5174"));
 
         result = mock.Object.input("index.scss");
-        Assert.AreEqual(result.ToString(), "<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
-            "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t");
+        Assert.That(result.ToString(), Is.EqualTo("<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
+           "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t"));
     }
 
 }

--- a/InertiaCoreTests/UnitTestVite.cs
+++ b/InertiaCoreTests/UnitTestVite.cs
@@ -48,6 +48,30 @@ public partial class Tests
     }
 
     [Test]
+    public void TestProperties()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData> { });
+
+        var mock = new Mock<ViteBuilder>(fileSystem);
+
+        mock.Object.useBuildDirectory("build2");
+
+        Assert.That(mock.Object.getBuildDirectory(), Is.EqualTo("build2"));
+
+        mock.Object.usePublicDirectory("public");
+
+        Assert.That(mock.Object.getPublicDirectory(), Is.EqualTo("public"));
+
+        mock.Object.useManifestFilename("test.json");
+
+        Assert.That(mock.Object.getManifestFilename(), Is.EqualTo("test.json"));
+
+        mock.Object.useHotFile("cold");
+
+        Assert.That(mock.Object.getHotFile(), Is.EqualTo("cold"));
+    }
+
+    [Test]
     public void TestViteInput()
     {
 

--- a/InertiaCoreTests/UnitTestVite.cs
+++ b/InertiaCoreTests/UnitTestVite.cs
@@ -101,7 +101,7 @@ public partial class Tests
 
         var result = mock.Object.Input("app.tsx");
         Assert.That(result.ToString(),
-            Is.EqualTo("<script src=\"/build/assets/main-19038c6a.js\" type=\"text/javascript\"></script>\n\t"));
+            Is.EqualTo("<script src=\"/build/assets/main-19038c6a.js\" type=\"module\"></script>\n\t"));
 
         // Basic JS File with CSS import
         fileSystem.AddFile(@"/wwwroot/build/manifest.json",
@@ -110,7 +110,7 @@ public partial class Tests
         result = mock.Object.Input("app.tsx");
         Assert.That(result.ToString(),
             Is.EqualTo(
-                "<script src=\"/build/assets/main.js\" type=\"text/javascript\"></script>\n\t<link href=\"/build/assets/index.css\" rel=\"stylesheet\" />\n\t"));
+                "<script src=\"/build/assets/main.js\" type=\"module\"></script>\n\t<link href=\"/build/assets/index.css\" rel=\"stylesheet\" />\n\t"));
 
         // Basic CSS file
         fileSystem.AddFile(@"/wwwroot/build/manifest.json",

--- a/InertiaCoreTests/UnitTestVite.cs
+++ b/InertiaCoreTests/UnitTestVite.cs
@@ -109,12 +109,40 @@ public partial class Tests
         result = mock.Object.input("index.scss");
         Assert.That(result.ToString(), Is.EqualTo("<link href=\"/build/assets/index.css\" rel=\"stylesheet\" />\n\t"));
 
+        // Basic CSS file with custom builder dir
+        fileSystem.AddFile(@"/wwwroot/manifest.json", new MockFileData("{\"index.scss\": {\"file\": \"assets/index.css\"}}"));
+        mock.Object.useBuildDirectory(null);
+        result = mock.Object.input("index.scss");
+        Assert.That(result.ToString(), Is.EqualTo("<link href=\"/assets/index.css\" rel=\"stylesheet\" />\n\t"));
+
+
         // Hot file with css import
+        mock.Object.useBuildDirectory("build");
         fileSystem.AddFile(@"/wwwroot/build/hot", new MockFileData("http://127.0.0.1:5174"));
 
         result = mock.Object.input("index.scss");
         Assert.That(result.ToString(), Is.EqualTo("<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
            "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t"));
+
+        // Test null build directory
+        fileSystem.AddFile(@"/wwwroot/hot", new MockFileData("http://127.0.0.1:5174"));
+        mock.Object.useBuildDirectory(null);
+        result = mock.Object.input("index.scss");
+        Assert.That(result.ToString(), Is.EqualTo("<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
+           "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t"));
+
+        // Test empty build directory
+        mock.Object.useBuildDirectory("");
+        result = mock.Object.input("index.scss");
+        Assert.That(result.ToString(), Is.EqualTo("<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
+           "<script src=\"http://127.0.0.1:5174/index.scss\" type=\"module\"></script>\n\t"));
+
+        // Basic JS File via hot
+        // fileSystem.AddFile(@"/wwwroot/build/manifest.json", new MockFileData("{\"app.tsx\": {\"file\": \"assets/main-19038c6a.js\"}}"));
+
+        result = mock.Object.input("app.tsx");
+        Assert.That(result.ToString(), Is.EqualTo("<script src=\"http://127.0.0.1:5174/@vite/client\" type=\"module\"></script>\n\t" +
+            "<script src=\"http://127.0.0.1:5174/app.tsx\" type=\"module\"></script>\n\t"));
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -177,3 +177,168 @@ builder.Services.AddInertia(options =>
     options.SsrUrl = "http://127.0.0.1:13714/render"; // default
 });
 ```
+
+### Vite Helper
+
+A Vite helper class is available to automatically load your generated styles or scripts by simply using the `@Vite.Input("src/main.tsx")` helper. You can also enable HMR when using React by using the `@Vite.ReactRefresh()` helper. This pairs well with the `laravel-vite-plugin` npm package.
+
+To get started with the Vite Helper, you will need to add one more line to the `Program.cs` or `Starup.cs` file.
+
+```csharp
+using InertiaCore.Extensions;
+
+[...]
+
+builder.Services.AddViteHelper();
+
+// Or with options (default values shown)
+
+builder.Services.AddViteHelper(options =>
+{
+    options.PublicDirectory = "wwwroot";
+    options.BuildDirectory = "build";
+    options.HotFile = "hot";
+    options.ManifestFilename = "manifest.json";
+});
+```
+
+#### Examples
+---
+
+Here's an example for a TypeScript React app with HMR:
+
+```html
+@using InertiaCore
+@using InertiaCore.Utils
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title inertia>My App</title>
+  </head>
+  <body>
+    @* This has to go first, otherwise preamble error *@
+    @Vite.ReactRefresh()
+    @await Inertia.Html(Model)
+    @Vite.Input("src/main.tsx")
+  </body>
+</html>
+```
+
+And here is the corresponding `vite.config.js`
+
+```js
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import laravel from "laravel-vite-plugin";
+import path from "path";
+import { mkdirSync } from "fs";
+
+// Auto-initialize the default output directory
+const outDir = "../wwwroot/build";
+
+mkdirSync(outDir, { recursive: true });
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    laravel({
+      input: ["src/main.tsx"],
+      publicDirectory: outDir,
+    }),
+    react(),
+  ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+  build: {
+    outDir,
+    emptyOutDir: true,
+  },
+});
+```
+
+---
+
+Here's an example for a TypeScript Vue app with Hot Reload:
+
+```html
+@using InertiaCore
+@using InertiaCore.Utils
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title inertia>My App</title>
+  </head>
+  <body>
+    @await Inertia.Html(Model)
+    @Vite.Input("src/app.ts")
+  </body>
+</html>
+```
+
+And here is the corresponding `vite.config.js`
+
+```js
+import {defineConfig} from 'vite';
+import vue from '@vitejs/plugin-vue';
+import laravel from "laravel-vite-plugin";
+import path from "path";
+import {mkdirSync} from "fs";
+
+const outDir = "../wwwroot/build";
+
+mkdirSync(outDir, {recursive: true});
+
+export default defineConfig({
+  plugins: [
+    laravel({
+      input: ["src/app.ts"],
+      publicDirectory: outDir,
+      refresh: true,
+    }),
+    vue({
+      template: {
+        transformAssetUrls: {
+          base: null,
+          includeAbsolute: false,
+        },
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+  build: {
+    outDir,
+    emptyOutDir: true,
+  },
+});
+```
+
+---
+
+Here's an example that just produces a single CSS file:
+
+```html
+@using InertiaCore
+@using InertiaCore.Utils
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    @await Inertia.Html(Model)
+    @Vite.Input("src/main.scss")
+  </body>
+</html>
+```


### PR DESCRIPTION
One thing I was longing for when using this package was a way to easily integrate Vite and HMR. This is a basic class that added some helper methods to make this a bit easier to integrate. 

It works in tandem with [laravel-vite-plugin](https://github.com/laravel/vite-plugin), and the class is loosely inspired by https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/Vite.php

An example project exists at https://github.com/adrum/dotnet-inertia-react 

It basically allows you to do something like this:

```cshtml
# App.cshtml
   ...
    @Vite.reactRefresh()
    @await Inertia.Html(Model)
    @Vite.input("src/main.tsx")
```

I referenced a non-existent version of this project by adding the following to the root of the project at `NuGet.Config`

```
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <packageSources>
    <add key="local-packages" value="/path/to/InertiaCore/InertiaCore/bin/Debug" />
  </packageSources>
</configuration>
```


