### PR TITLE
Add ability for deferred props 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+/.vs

--- a/InertiaCore/Inertia.cs
+++ b/InertiaCore/Inertia.cs
@@ -29,4 +29,5 @@ public static class Inertia
     public static void Share(IDictionary<string, object?> data) => _factory.Share(data);
 
     public static LazyProp Lazy(Func<object?> callback) => _factory.Lazy(callback);
+    public static DeferProp Defer(Func<object?> callback) => _factory.Defer(callback);
 }

--- a/InertiaCore/Models/Page.cs
+++ b/InertiaCore/Models/Page.cs
@@ -3,6 +3,7 @@ namespace InertiaCore.Models;
 internal class Page
 {
     public Dictionary<string, object?> Props { get; set; } = default!;
+    public Dictionary<string, object?>? DeferProps { get; set; } = default!;
     public string Component { get; set; } = default!;
     public string? Version { get; set; }
     public string Url { get; set; } = default!;

--- a/InertiaCore/Response.cs
+++ b/InertiaCore/Response.cs
@@ -57,16 +57,14 @@ public class Response : IActionResult
 
             page.Props = props;
 
-
-            var _deferProps = _props.GetType().GetProperties()
+            var deferProps = _props.GetType().GetProperties()
                 .Where(o => o.PropertyType == typeof(DeferProp))
                 .ToDictionary(o => o.Name.ToCamelCase(), o => o.GetValue(_props));
 
-            if (_deferProps != null) page.DeferProps = PrepareProps(_deferProps);
+            page.DeferProps = PrepareProps(deferProps);
         }
 
         page.Props = PrepareProps(page.Props);
-
 
         var shared = _context!.HttpContext.Features.Get<InertiaSharedData>();
         if (shared != null)

--- a/InertiaCore/Response.cs
+++ b/InertiaCore/Response.cs
@@ -52,13 +52,21 @@ public class Response : IActionResult
         else
         {
             var props = _props.GetType().GetProperties()
-                .Where(o => o.PropertyType != typeof(LazyProp))
+                .Where(o => o.PropertyType != typeof(LazyProp) && o.PropertyType != typeof(DeferProp))
                 .ToDictionary(o => o.Name.ToCamelCase(), o => o.GetValue(_props));
 
             page.Props = props;
+
+
+            var _deferProps = _props.GetType().GetProperties()
+                .Where(o => o.PropertyType == typeof(DeferProp))
+                .ToDictionary(o => o.Name.ToCamelCase(), o => o.GetValue(_props));
+
+            if (_deferProps != null) page.DeferProps = PrepareProps(_deferProps);
         }
 
         page.Props = PrepareProps(page.Props);
+
 
         var shared = _context!.HttpContext.Features.Get<InertiaSharedData>();
         if (shared != null)

--- a/InertiaCore/ResponseFactory.cs
+++ b/InertiaCore/ResponseFactory.cs
@@ -22,6 +22,7 @@ internal interface IResponseFactory
     public void Share(string key, object? value);
     public void Share(IDictionary<string, object?> data);
     public LazyProp Lazy(Func<object?> callback);
+    public DeferProp Defer(Func<object?> callback);
 }
 
 internal class ResponseFactory : IResponseFactory
@@ -119,4 +120,6 @@ internal class ResponseFactory : IResponseFactory
     }
 
     public LazyProp Lazy(Func<object?> callback) => new(callback);
+
+    public DeferProp Defer(Func<object?> callback) => new(callback);
 }

--- a/InertiaCore/Utils/DeferProp.cs
+++ b/InertiaCore/Utils/DeferProp.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace InertiaCore.Utils;
 
-namespace InertiaCore.Utils
+public class DeferProp : LazyProp
 {
-    public class DeferProp : LazyProp
+    public DeferProp(Func<object?> callback) : base(callback)
     {
-        public DeferProp(Func<object?> callback) : base(callback)
-        {
-        }
     }
 }

--- a/InertiaCore/Utils/DeferProp.cs
+++ b/InertiaCore/Utils/DeferProp.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InertiaCore.Utils
+{
+    public class DeferProp : LazyProp
+    {
+        public DeferProp(Func<object?> callback) : base(callback)
+        {
+        }
+    }
+}

--- a/InertiaCoreTests/UnitTestDeferData.cs
+++ b/InertiaCoreTests/UnitTestDeferData.cs
@@ -1,0 +1,74 @@
+using InertiaCore.Models;
+using Microsoft.AspNetCore.Http;
+
+namespace InertiaCoreTests;
+
+public partial class Tests
+{
+    [Test]
+    [Description("Test if the defer data is fetched properly.")]
+    public void TestDeferData()
+    {
+        var response = _factory.Render("Test/Page", new
+        {
+            Test = "Test",
+            TestFunc = new Func<string>(() => "Func"),
+            TestDefer = _factory.Defer(() =>
+            {
+                Assert.Pass();
+                return "Defer";
+            }),
+            TestLazy = _factory.Lazy(() =>
+            {
+                Assert.Fail();
+                return "Lazy";
+            })
+        });
+
+        var context = PrepareContext();
+
+        response.SetContext(context);
+        response.ProcessResponse();
+
+        var page = response.GetJson().Value as Page;
+
+        Assert.That(page?.Props, Is.EqualTo(new Dictionary<string, object?>
+        {
+            { "test", "Test" },
+            { "testFunc", "Func" },
+            { "testDefer", "Defer" },
+            { "errors", new Dictionary<string, string>(0) }
+        }));
+    }
+
+    [Test]
+    [Description("Test if the Defer data is fetched properly with specified partial props.")]
+    public void TestDeferPartialData()
+    {
+        var response = _factory.Render("Test/Page", new
+        {
+            TestFunc = new Func<string>(() => "Func"),
+            TestDefer = _factory.Defer(() => "Defer")
+        });
+
+        var headers = new HeaderDictionary
+        {
+            { "X-Inertia-Partial-Data", "testFunc,testDefer" },
+            { "X-Inertia-Partial-Component", "Test/Page" }
+        };
+
+        var context = PrepareContext(headers);
+
+        response.SetContext(context);
+        response.ProcessResponse();
+
+        var page = response.GetJson().Value as Page;
+
+        Assert.That(page?.Props, Is.EqualTo(new Dictionary<string, object?>
+        {
+            { "testFunc", "Func" },
+            { "testDefer", "Defer" },
+            { "errors", new Dictionary<string, string>(0) }
+        }));
+    }
+}

--- a/InertiaCoreTests/UnitTestPartialData.cs
+++ b/InertiaCoreTests/UnitTestPartialData.cs
@@ -22,6 +22,11 @@ public partial class Tests
             {
                 Assert.Fail();
                 return "Lazy";
+            }),
+            TestDefer = _factory.Defer(() =>
+            {
+                Assert.Fail();
+                return "Defer";
             })
         });
 


### PR DESCRIPTION
This works in tandem with [inertiajs/inertia#1617](https://github.com/inertiajs/inertia/pull/1617). This is the server-side implementation of having props that defer loading. They behave the same as lazy props, except on load. This allows properties to be loaded automatically after page loads/navigation.

Basically just a port of the PR [inertiajs/inertia-laravel#531](https://github.com/inertiajs/inertia-laravel/pull/531) from @adrum 