### PR TITLE
[1.x] Fix some compile time warnings with .NET 8/9

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 9.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/InertiaCore/Extensions/Configure.cs
+++ b/InertiaCore/Extensions/Configure.cs
@@ -69,7 +69,7 @@ public static class Configure
 
         if (tempData.Any()) tempData.Keep();
 
-        context.Response.Headers.Add("X-Inertia-Location", context.RequestedUri());
+        context.Response.Headers.Override(Header.Location, context.RequestedUri());
         context.Response.StatusCode = (int)HttpStatusCode.Conflict;
 
         await context.Response.CompleteAsync();

--- a/InertiaCore/Extensions/Configure.cs
+++ b/InertiaCore/Extensions/Configure.cs
@@ -69,7 +69,7 @@ public static class Configure
 
         if (tempData.Any()) tempData.Keep();
 
-        context.Response.Headers.Override(Header.Location, context.RequestedUri());
+        context.Response.Headers.Override("X-Inertia-Location", context.RequestedUri());
         context.Response.StatusCode = (int)HttpStatusCode.Conflict;
 
         await context.Response.CompleteAsync();

--- a/InertiaCore/Extensions/InertiaExtensions.cs
+++ b/InertiaCore/Extensions/InertiaExtensions.cs
@@ -31,4 +31,16 @@ internal static class InertiaExtensions
     internal static bool IsInertiaRequest(this ActionContext context) => context.HttpContext.IsInertiaRequest();
 
     internal static string ToCamelCase(this string s) => JsonNamingPolicy.CamelCase.ConvertName(s);
+
+    internal static bool Override<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
+    {
+        if (dictionary.ContainsKey(key))
+        {
+            dictionary[key] = value;
+            return true;
+        }
+
+        dictionary.Add(key, value);
+        return false;
+    }
 }

--- a/InertiaCore/InertiaCore.csproj
+++ b/InertiaCore/InertiaCore.csproj
@@ -3,7 +3,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Version>0.0.9</Version>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <PackageId>AspNetCore.InertiaCore</PackageId>
         <Authors>kapi2289</Authors>
         <Description>Inertia.js ASP.NET Adapter. https://inertiajs.com/</Description>

--- a/InertiaCore/InertiaCore.csproj
+++ b/InertiaCore/InertiaCore.csproj
@@ -3,7 +3,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Version>0.0.9</Version>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <PackageId>AspNetCore.InertiaCore</PackageId>
         <Authors>kapi2289</Authors>
         <Description>Inertia.js ASP.NET Adapter. https://inertiajs.com/</Description>

--- a/InertiaCore/Response.cs
+++ b/InertiaCore/Response.cs
@@ -81,8 +81,8 @@ public class Response : IActionResult
 
     protected internal JsonResult GetJson()
     {
-        _context!.HttpContext.Response.Headers.Add("X-Inertia", "true");
-        _context!.HttpContext.Response.Headers.Add("Vary", "Accept");
+        _context!.HttpContext.Response.Headers.Override(Header.Inertia, "true");
+        _context!.HttpContext.Response.Headers.Override("Vary", "Accept");
         _context!.HttpContext.Response.StatusCode = 200;
 
         return new JsonResult(_page, new JsonSerializerOptions

--- a/InertiaCore/Response.cs
+++ b/InertiaCore/Response.cs
@@ -81,7 +81,7 @@ public class Response : IActionResult
 
     protected internal JsonResult GetJson()
     {
-        _context!.HttpContext.Response.Headers.Override(Header.Inertia, "true");
+        _context!.HttpContext.Response.Headers.Override("X-Inertia", "true");
         _context!.HttpContext.Response.Headers.Override("Vary", "Accept");
         _context!.HttpContext.Response.StatusCode = 200;
 

--- a/InertiaCore/Utils/InertiaActionFilter.cs
+++ b/InertiaCore/Utils/InertiaActionFilter.cs
@@ -32,7 +32,7 @@ internal class InertiaActionFilter : IActionFilter
         };
 
         if (destinationUrl == null) return;
-        context.HttpContext.Response.Headers.Add("Location", destinationUrl);
+        context.HttpContext.Response.Headers.Override("Location", destinationUrl);
         context.Result = new StatusCodeResult((int)HttpStatusCode.RedirectMethod);
     }
 

--- a/InertiaCore/Utils/LocationResult.cs
+++ b/InertiaCore/Utils/LocationResult.cs
@@ -14,7 +14,7 @@ public class LocationResult : IActionResult
     {
         if (context.IsInertiaRequest())
         {
-            context.HttpContext.Response.Headers.Add("X-Inertia-Location", _url);
+            context.HttpContext.Response.Headers.Override(Header.Location, _url);
             await new StatusCodeResult((int)HttpStatusCode.Conflict).ExecuteResultAsync(context);
             return;
         }

--- a/InertiaCore/Utils/LocationResult.cs
+++ b/InertiaCore/Utils/LocationResult.cs
@@ -14,7 +14,7 @@ public class LocationResult : IActionResult
     {
         if (context.IsInertiaRequest())
         {
-            context.HttpContext.Response.Headers.Override(Header.Location, _url);
+            context.HttpContext.Response.Headers.Override("X-Inertia-Location", _url);
             await new StatusCodeResult((int)HttpStatusCode.Conflict).ExecuteResultAsync(context);
             return;
         }

--- a/InertiaCoreTests/InertiaCoreTests.csproj
+++ b/InertiaCoreTests/InertiaCoreTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/InertiaCoreTests/InertiaCoreTests.csproj
+++ b/InertiaCoreTests/InertiaCoreTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 


### PR DESCRIPTION
I was getting the following:

```
/projects/InertiaCore/InertiaCore/Response.cs(66,9): warning ASP0019: Use IHeaderDictionary.Append or the indexer to append or set headers. IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key. (https://aka.ms/aspnet/analyzers) /projects/InertiaCore/InertiaCore/InertiaCore.csproj::TargetFramework=net8.0]
/projects/InertiaCore/InertiaCore/Response.cs(67,9): warning ASP0019: Use IHeaderDictionary.Append or the indexer to append or set headers. IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key. (https://aka.ms/aspnet/analyzers) /projects/InertiaCore/InertiaCore/InertiaCore.csproj::TargetFramework=net8.0]
/projects/InertiaCore/InertiaCore/Utils/InertiaActionFilter.cs(35,9): warning ASP0019: Use IHeaderDictionary.Append or the indexer to append or set headers. IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key. (https://aka.ms/aspnet/analyzers) /projects/InertiaCore/InertiaCore/InertiaCore.csproj::TargetFramework=net8.0]
/projects/InertiaCore/InertiaCore/Extensions/Configure.cs(72,9): warning ASP0019: Use IHeaderDictionary.Append or the indexer to append or set headers. IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key. (https://aka.ms/aspnet/analyzers) /projects/InertiaCore/InertiaCore/InertiaCore.csproj::TargetFramework=net8.0]
/projects/InertiaCore/InertiaCore/Utils/LocationResult.cs(17,13): warning ASP0019: Use IHeaderDictionary.Append or the indexer to append or set headers. IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key. (https://aka.ms/aspnet/analyzers) /projects/InertiaCore/InertiaCore/InertiaCore.csproj::TargetFramework=net8.0]
```

If/when accepted, it could also be merged into main.