### PR TITLE
Update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Here's an example for a TypeScript React app with HMR:
 </html>
 ```
 
-with the corresponding `vite.config.js`, which is recommended to create in the root solution directory:
+with the corresponding `vite.config.js`, which is recommended to create in the `ClientApp` directory:
 
 ```js
 import { defineConfig } from "vite";
@@ -278,10 +278,13 @@ export default defineConfig({
   plugins: [
     laravel({
       input: ["src/main.tsx"],
-      publicDirectory: "wwwroot/",
+      publicDirectory: "../wwwroot/",
     }),
     react(),
   ],
+  build: {
+    emptyOutDir: true,
+  },
 });
 ```
 
@@ -306,7 +309,7 @@ Here's an example for a TypeScript Vue app with Hot Reload:
 </html>
 ```
 
-with the corresponding `vite.config.js`, which is recommended to create in the root solution directory:
+with the corresponding `vite.config.js`, which is recommended to create in the `ClientApp` directory:
 
 ```js
 import {defineConfig} from 'vite';
@@ -317,7 +320,7 @@ export default defineConfig({
   plugins: [
     laravel({
       input: ["src/app.ts"],
-      publicDirectory: "wwwroot/",
+      publicDirectory: "../wwwroot/",
       refresh: true,
     }),
     vue({
@@ -329,6 +332,9 @@ export default defineConfig({
       },
     }),
   ],
+  build: {
+    emptyOutDir: true,
+  },
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -266,38 +266,22 @@ Here's an example for a TypeScript React app with HMR:
 </html>
 ```
 
-And here is the corresponding `vite.config.js`
+with the corresponding `vite.config.js`, which is recommended to create in the root solution directory:
 
 ```js
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import laravel from "laravel-vite-plugin";
-import path from "path";
-import { mkdirSync } from "fs";
-
-// Auto-initialize the default output directory
-const outDir = "../wwwroot/build";
-
-mkdirSync(outDir, { recursive: true });
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     laravel({
       input: ["src/main.tsx"],
-      publicDirectory: outDir,
+      publicDirectory: "wwwroot/",
     }),
     react(),
   ],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "src"),
-    },
-  },
-  build: {
-    outDir,
-    emptyOutDir: true,
-  },
 });
 ```
 
@@ -322,24 +306,18 @@ Here's an example for a TypeScript Vue app with Hot Reload:
 </html>
 ```
 
-And here is the corresponding `vite.config.js`
+with the corresponding `vite.config.js`, which is recommended to create in the root solution directory:
 
 ```js
 import {defineConfig} from 'vite';
 import vue from '@vitejs/plugin-vue';
 import laravel from "laravel-vite-plugin";
-import path from "path";
-import {mkdirSync} from "fs";
-
-const outDir = "../wwwroot/build";
-
-mkdirSync(outDir, {recursive: true});
 
 export default defineConfig({
   plugins: [
     laravel({
       input: ["src/app.ts"],
-      publicDirectory: outDir,
+      publicDirectory: "wwwroot/",
       refresh: true,
     }),
     vue({
@@ -351,15 +329,6 @@ export default defineConfig({
       },
     }),
   ],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "src"),
-    },
-  },
-  build: {
-    outDir,
-    emptyOutDir: true,
-  },
 });
 ```
 


### PR DESCRIPTION
After some testing, I've come up with an easier to understand and maintain `vite.config.js` configuration, which is also closer to the default Laravel usage.

@adrum, as you have proposed the previous examples, I would appreciate an opinion on it. Thanks in advance.