### PR TITLE
[1.x] Properly resolve nested properties

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,7 +23,11 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: |
+          6.0.x
+          7.0.x
+          8.0.x
+          9.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/InertiaCore/Extensions/InertiaExtensions.cs
+++ b/InertiaCore/Extensions/InertiaExtensions.cs
@@ -8,31 +8,6 @@ namespace InertiaCore.Extensions;
 
 internal static class InertiaExtensions
 {
-    internal static Dictionary<string, object?> OnlyProps(this ActionContext context, Dictionary<string, object?> props)
-    {
-        var onlyKeys = context.HttpContext.Request.Headers[InertiaHeader.PartialOnly]
-            .ToString().Split(',')
-            .Select(k => k.Trim())
-            .Where(k => !string.IsNullOrEmpty(k))
-            .ToList();
-
-        return props.Where(kv => onlyKeys.Contains(kv.Key, StringComparer.OrdinalIgnoreCase))
-            .ToDictionary(kv => kv.Key, kv => kv.Value);
-    }
-
-    internal static Dictionary<string, object?> ExceptProps(this ActionContext context,
-        Dictionary<string, object?> props)
-    {
-        var exceptKeys = context.HttpContext.Request.Headers[InertiaHeader.PartialExcept]
-            .ToString().Split(',')
-            .Select(k => k.Trim())
-            .Where(k => !string.IsNullOrEmpty(k))
-            .ToList();
-
-        return props.Where(kv => exceptKeys.Contains(kv.Key, StringComparer.OrdinalIgnoreCase) == false)
-            .ToDictionary(kv => kv.Key, kv => kv.Value);
-    }
-
     internal static bool IsInertiaPartialComponent(this ActionContext context, string component) =>
         context.HttpContext.Request.Headers[InertiaHeader.PartialComponent] == component;
 
@@ -54,5 +29,24 @@ internal static class InertiaExtensions
         dictionary[key] = value;
 
         return true;
+    }
+
+    internal static Task<object?> ResolveAsync(this Func<object?> func)
+    {
+        var rt = func.Method.ReturnType;
+
+        if (!rt.IsGenericType || rt.GetGenericTypeDefinition() != typeof(Task<>))
+            return Task.Run(func.Invoke);
+
+        var task = func.DynamicInvoke() as Task;
+        return task!.ResolveResult();
+    }
+
+    internal static async Task<object?> ResolveResult(this Task task)
+    {
+        await task.ConfigureAwait(false);
+        var result = task.GetType().GetProperty("Result");
+
+        return result?.GetValue(task);
     }
 }

--- a/InertiaCore/Props/InvokableProp.cs
+++ b/InertiaCore/Props/InvokableProp.cs
@@ -1,3 +1,5 @@
+using InertiaCore.Extensions;
+
 namespace InertiaCore.Props;
 
 public class InvokableProp
@@ -10,9 +12,9 @@ public class InvokableProp
     {
         return _value switch
         {
-            Func<Task<object?>> asyncCallable => asyncCallable.Invoke(),
-            Func<object?> callable => Task.Run(() => callable.Invoke()),
-            Task<object?> value => value,
+            Func<object?> f => f.ResolveAsync(),
+            Task t => t.ResolveResult(),
+            InvokableProp p => p.Invoke(),
             _ => Task.FromResult(_value)
         };
     }

--- a/InertiaCore/Response.cs
+++ b/InertiaCore/Response.cs
@@ -13,7 +13,7 @@ namespace InertiaCore;
 public class Response : IActionResult
 {
     private readonly string _component;
-    private readonly object _props;
+    private readonly Dictionary<string, object?> _props;
     private readonly string _rootView;
     private readonly string? _version;
 
@@ -21,46 +21,136 @@ public class Response : IActionResult
     private Page? _page;
     private IDictionary<string, object>? _viewData;
 
-    public Response(string component, object props, string rootView, string? version)
+    internal Response(string component, Dictionary<string, object?> props, string rootView, string? version)
         => (_component, _props, _rootView, _version) = (component, props, rootView, version);
 
     public async Task ExecuteResultAsync(ActionContext context)
     {
         SetContext(context);
         await ProcessResponse();
-
         await GetResult().ExecuteResultAsync(_context!);
     }
 
     protected internal async Task ProcessResponse()
     {
+        var props = await ResolveProperties();
+
         var page = new Page
         {
             Component = _component,
             Version = _version,
             Url = _context!.RequestedUri(),
-            Props = await ResolveProperties(_props.GetType().GetProperties()
-                .ToDictionary(o => o.Name.ToCamelCase(), o => o.GetValue(_props)))
+            Props = props
         };
-
-        var shared = _context!.HttpContext.Features.Get<InertiaSharedData>();
-        if (shared != null)
-            page.Props = shared.GetMerged(page.Props);
 
         page.Props["errors"] = GetErrors();
 
         SetPage(page);
     }
 
-    private static async Task<Dictionary<string, object?>> PrepareProps(Dictionary<string, object?> props)
+    /// <summary>
+    /// Resolve the properties for the response.
+    /// </summary>
+    private async Task<Dictionary<string, object?>> ResolveProperties()
     {
-        return (await Task.WhenAll(props.Select(async pair => pair.Value switch
+        var props = _props;
+
+        props = ResolvePartialProperties(props);
+        props = ResolveAlways(props);
+        props = await ResolvePropertyInstances(props);
+
+        return props;
+    }
+
+    /// <summary>
+    /// Resolve the `only` and `except` partial request props.
+    /// </summary>
+    private Dictionary<string, object?> ResolvePartialProperties(Dictionary<string, object?> props)
+    {
+        var isPartial = _context!.IsInertiaPartialComponent(_component);
+
+        if (!isPartial)
+            return props
+                .Where(kv => kv.Value is not LazyProp)
+                .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        props = props.ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        if (_context!.HttpContext.Request.Headers.ContainsKey(InertiaHeader.PartialOnly))
+            props = ResolveOnly(props);
+
+        if (_context!.HttpContext.Request.Headers.ContainsKey(InertiaHeader.PartialExcept))
+            props = ResolveExcept(props);
+
+        return props;
+    }
+
+    /// <summary>
+    /// Resolve the `only` partial request props.
+    /// </summary>
+    private Dictionary<string, object?> ResolveOnly(Dictionary<string, object?> props)
+    {
+        var onlyKeys = _context!.HttpContext.Request.Headers[InertiaHeader.PartialOnly]
+            .ToString().Split(',')
+            .Select(k => k.Trim())
+            .Where(k => !string.IsNullOrEmpty(k))
+            .ToList();
+
+        return props.Where(kv => onlyKeys.Contains(kv.Key, StringComparer.OrdinalIgnoreCase))
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+    }
+
+    /// <summary>
+    /// Resolve the `except` partial request props.
+    /// </summary>
+    private Dictionary<string, object?> ResolveExcept(Dictionary<string, object?> props)
+    {
+        var exceptKeys = _context!.HttpContext.Request.Headers[InertiaHeader.PartialExcept]
+            .ToString().Split(',')
+            .Select(k => k.Trim())
+            .Where(k => !string.IsNullOrEmpty(k))
+            .ToList();
+
+        return props.Where(kv => exceptKeys.Contains(kv.Key, StringComparer.OrdinalIgnoreCase) == false)
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+    }
+
+    /// <summary>
+    /// Resolve `always` properties that should always be included on all visits, regardless of "only" or "except" requests.
+    /// </summary>
+    private Dictionary<string, object?> ResolveAlways(Dictionary<string, object?> props)
+    {
+        var alwaysProps = _props.Where(o => o.Value is AlwaysProp);
+
+        return props
+            .Where(kv => kv.Value is not AlwaysProp)
+            .Concat(alwaysProps).ToDictionary(kv => kv.Key, kv => kv.Value);
+    }
+
+    /// <summary>
+    /// Resolve all necessary class instances in the given props.
+    /// </summary>
+    private static async Task<Dictionary<string, object?>> ResolvePropertyInstances(Dictionary<string, object?> props)
+    {
+        return (await Task.WhenAll(props.Select(async pair =>
         {
-            Func<object?> f => (pair.Key, f.Invoke()),
-            LazyProp l => (pair.Key, await l.Invoke()),
-            AlwaysProp l => (pair.Key, await l.Invoke()),
-            _ => (pair.Key, pair.Value)
-        }))).ToDictionary(pair => pair.Key, pair => pair.Item2);
+            var key = pair.Key.ToCamelCase();
+
+            var value = pair.Value switch
+            {
+                Func<object?> f => (key, await f.ResolveAsync()),
+                Task t => (key, await t.ResolveResult()),
+                InvokableProp p => (key, await p.Invoke()),
+                _ => (key, pair.Value)
+            };
+
+            if (value.Item2 is Dictionary<string, object?> dict)
+            {
+                value = (key, await ResolvePropertyInstances(dict));
+            }
+
+            return value;
+        }))).ToDictionary(pair => pair.key, pair => pair.Item2);
     }
 
     protected internal JsonResult GetJson()
@@ -93,7 +183,7 @@ public class Response : IActionResult
 
     protected internal IActionResult GetResult() => _context!.IsInertiaRequest() ? GetJson() : GetView();
 
-    private IDictionary<string, string> GetErrors()
+    private Dictionary<string, string> GetErrors()
     {
         if (!_context!.ModelState.IsValid)
             return _context!.ModelState.ToDictionary(o => o.Key.ToCamelCase(),
@@ -110,49 +200,5 @@ public class Response : IActionResult
     {
         _viewData = viewData;
         return this;
-    }
-
-    private async Task<Dictionary<string, object?>> ResolveProperties(Dictionary<string, object?> props)
-    {
-        var isPartial = _context!.IsInertiaPartialComponent(_component);
-
-        if (!isPartial)
-        {
-            props = props
-                .Where(kv => kv.Value is not LazyProp)
-                .ToDictionary(kv => kv.Key, kv => kv.Value);
-        }
-        else
-        {
-            props = props.ToDictionary(kv => kv.Key, kv => kv.Value);
-
-            if (_context!.HttpContext.Request.Headers.ContainsKey(InertiaHeader.PartialOnly))
-                props = ResolveOnly(props);
-
-            if (_context!.HttpContext.Request.Headers.ContainsKey(InertiaHeader.PartialExcept))
-                props = ResolveExcept(props);
-        }
-
-        props = ResolveAlways(props);
-        props = await PrepareProps(props);
-
-        return props;
-    }
-
-    private Dictionary<string, object?> ResolveOnly(Dictionary<string, object?> props)
-        => _context!.OnlyProps(props);
-
-    private Dictionary<string, object?> ResolveExcept(Dictionary<string, object?> props)
-        => _context!.ExceptProps(props);
-
-    private Dictionary<string, object?> ResolveAlways(Dictionary<string, object?> props)
-    {
-        var alwaysProps = _props.GetType().GetProperties()
-            .Where(o => o.PropertyType == typeof(AlwaysProp))
-            .ToDictionary(o => o.Name.ToCamelCase(), o => o.GetValue(_props));
-
-        return props
-            .Where(kv => kv.Value is not AlwaysProp)
-            .Concat(alwaysProps).ToDictionary(kv => kv.Key, kv => kv.Value);
     }
 }

--- a/InertiaCore/Response.cs
+++ b/InertiaCore/Response.cs
@@ -55,9 +55,22 @@ public class Response : IActionResult
     {
         var props = _props;
 
+        props = ResolveSharedProps(props);
         props = ResolvePartialProperties(props);
         props = ResolveAlways(props);
         props = await ResolvePropertyInstances(props);
+
+        return props;
+    }
+
+    /// <summary>
+    /// Resolve `shared` props stored in the current request context.
+    /// </summary>
+    private Dictionary<string, object?> ResolveSharedProps(Dictionary<string, object?> props)
+    {
+        var shared = _context!.HttpContext.Features.Get<InertiaSharedProps>();
+        if (shared != null)
+            props = shared.GetMerged(props);
 
         return props;
     }

--- a/InertiaCore/Utils/InertiaSharedProps.cs
+++ b/InertiaCore/Utils/InertiaSharedProps.cs
@@ -2,7 +2,7 @@ using InertiaCore.Extensions;
 
 namespace InertiaCore.Utils;
 
-internal class InertiaSharedData
+internal class InertiaSharedProps
 {
     private IDictionary<string, object?>? Data { get; set; }
 

--- a/InertiaCoreTests/Setup.cs
+++ b/InertiaCoreTests/Setup.cs
@@ -1,7 +1,9 @@
 using InertiaCore;
 using InertiaCore.Models;
 using InertiaCore.Ssr;
+using InertiaCore.Utils;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Routing;
@@ -31,9 +33,9 @@ public partial class Tests
     ///     Prepares ActionContext for usage in tests.
     /// </summary>
     /// <param name="headers">Optional request headers.</param>
-    /// <param name="sharedData">Optional Inertia shared data.</param>
+    /// <param name="sharedProps">Optional Inertia shared data.</param>
     /// <param name="modelState">Optional validation errors dictionary.</param>
-    private static ActionContext PrepareContext(HeaderDictionary? headers = null,
+    private static ActionContext PrepareContext(HeaderDictionary? headers = null, InertiaSharedProps? sharedProps = null,
         Dictionary<string, string>? modelState = null)
     {
         var request = new Mock<HttpRequest>();
@@ -42,9 +44,14 @@ public partial class Tests
         var response = new Mock<HttpResponse>();
         response.SetupGet(r => r.Headers).Returns(new HeaderDictionary());
 
+        var features = new FeatureCollection();
+        if (sharedProps != null)
+            features.Set(sharedProps);
+
         var httpContext = new Mock<HttpContext>();
         httpContext.SetupGet(c => c.Request).Returns(request.Object);
         httpContext.SetupGet(c => c.Response).Returns(response.Object);
+        httpContext.SetupGet(c => c.Features).Returns(features);
 
         var context = new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
 

--- a/InertiaCoreTests/Setup.cs
+++ b/InertiaCoreTests/Setup.cs
@@ -1,9 +1,7 @@
 using InertiaCore;
 using InertiaCore.Models;
 using InertiaCore.Ssr;
-using InertiaCore.Utils;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Routing;
@@ -35,7 +33,7 @@ public partial class Tests
     /// <param name="headers">Optional request headers.</param>
     /// <param name="sharedData">Optional Inertia shared data.</param>
     /// <param name="modelState">Optional validation errors dictionary.</param>
-    private static ActionContext PrepareContext(HeaderDictionary? headers = null, InertiaSharedData? sharedData = null,
+    private static ActionContext PrepareContext(HeaderDictionary? headers = null,
         Dictionary<string, string>? modelState = null)
     {
         var request = new Mock<HttpRequest>();
@@ -44,14 +42,9 @@ public partial class Tests
         var response = new Mock<HttpResponse>();
         response.SetupGet(r => r.Headers).Returns(new HeaderDictionary());
 
-        var features = new FeatureCollection();
-        if (sharedData != null)
-            features.Set(sharedData);
-
         var httpContext = new Mock<HttpContext>();
         httpContext.SetupGet(c => c.Request).Returns(request.Object);
         httpContext.SetupGet(c => c.Response).Returns(response.Object);
-        httpContext.SetupGet(c => c.Features).Returns(features);
 
         var context = new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
 

--- a/InertiaCoreTests/UnitTestAlwaysData.cs
+++ b/InertiaCoreTests/UnitTestAlwaysData.cs
@@ -67,17 +67,11 @@ public partial class Tests
     [Description("Test if the always async data is fetched properly.")]
     public async Task TestAlwaysAsyncData()
     {
-        var testFunction = new Func<Task<object?>>(async () =>
-        {
-            await Task.Delay(100);
-            return "Always Async";
-        });
-
         var response = _factory.Render("Test/Page", new
         {
             Test = "Test",
             TestFunc = new Func<string>(() => "Func"),
-            TestAlways = _factory.Always(testFunction)
+            TestAlways = _factory.Always(() => Task.FromResult<object?>("Always Async"))
         });
 
         var context = PrepareContext();
@@ -100,16 +94,10 @@ public partial class Tests
     [Description("Test if the always async data is fetched properly with specified partial props.")]
     public async Task TestAlwaysAsyncPartialData()
     {
-        var testFunction = new Func<Task<string>>(async () =>
-        {
-            await Task.Delay(100);
-            return "Always Async";
-        });
-
         var response = _factory.Render("Test/Page", new
         {
             TestFunc = new Func<string>(() => "Func"),
-            TestAlways = _factory.Always(async () => await testFunction())
+            TestAlways = _factory.Always(() => Task.FromResult<object?>("Always Async"))
         });
 
         var headers = new HeaderDictionary
@@ -137,16 +125,10 @@ public partial class Tests
     [Description("Test if the always async data is fetched properly without specified partial props.")]
     public async Task TestAlwaysAsyncPartialDataOmitted()
     {
-        var testFunction = new Func<Task<string>>(async () =>
-        {
-            await Task.Delay(100);
-            return "Always Async";
-        });
-
         var response = _factory.Render("Test/Page", new
         {
             TestFunc = new Func<string>(() => "Func"),
-            TestAlways = _factory.Always(async () => await testFunction())
+            TestAlways = _factory.Always(() => Task.FromResult<object?>("Always Async"))
         });
 
         var headers = new HeaderDictionary

--- a/InertiaCoreTests/UnitTestDictionaryData.cs
+++ b/InertiaCoreTests/UnitTestDictionaryData.cs
@@ -16,7 +16,7 @@ public partial class Tests
                 ["Key"] = () => "Value",
                 ["KeyAsync"] = () => Task.FromResult("ValueAsync"),
                 ["KeyAsync2"] = Task.FromResult("ValueAsync2"),
-                ["Always"] = () => new Dictionary<string, object>
+                ["Nested"] = () => new Dictionary<string, object>
                 {
                     ["Key"] = () => "Value"
                 }
@@ -40,7 +40,7 @@ public partial class Tests
                     { "keyAsync", "ValueAsync" },
                     { "keyAsync2", "ValueAsync2" },
                     {
-                        "always", new Dictionary<string, object?>
+                        "nested", new Dictionary<string, object?>
                         {
                             { "key", "Value" },
                         }

--- a/InertiaCoreTests/UnitTestDictionaryData.cs
+++ b/InertiaCoreTests/UnitTestDictionaryData.cs
@@ -1,0 +1,53 @@
+using InertiaCore.Models;
+
+namespace InertiaCoreTests;
+
+public partial class Tests
+{
+    [Test]
+    [Description("Test if all nested dictionaries and its values are resolved properly.")]
+    public async Task TestDictionaryData()
+    {
+        var response = _factory.Render("Test/Page", new
+        {
+            Test = "Test",
+            TestDict = new Dictionary<string, object>
+            {
+                ["Key"] = () => "Value",
+                ["KeyAsync"] = () => Task.FromResult("ValueAsync"),
+                ["KeyAsync2"] = Task.FromResult("ValueAsync2"),
+                ["Always"] = () => new Dictionary<string, object>
+                {
+                    ["Key"] = () => "Value"
+                }
+            }
+        });
+
+        var context = PrepareContext();
+        response.SetContext(context);
+
+        await response.ProcessResponse();
+
+        var page = response.GetJson().Value as Page;
+
+        Assert.That(page?.Props, Is.EqualTo(new Dictionary<string, object?>
+        {
+            { "test", "Test" },
+            {
+                "testDict", new Dictionary<string, object?>
+                {
+                    { "key", "Value" },
+                    { "keyAsync", "ValueAsync" },
+                    { "keyAsync2", "ValueAsync2" },
+                    {
+                        "always", new Dictionary<string, object?>
+                        {
+                            { "key", "Value" },
+                        }
+                    }
+                }
+            },
+            { "errors", new Dictionary<string, string>(0) }
+        }));
+    }
+}

--- a/InertiaCoreTests/UnitTestLazyData.cs
+++ b/InertiaCoreTests/UnitTestLazyData.cs
@@ -71,18 +71,15 @@ public partial class Tests
     [Description("Test if the lazy async data is fetched properly.")]
     public async Task TestLazyAsyncData()
     {
-        var testFunction = new Func<Task<object?>>(async () =>
-        {
-            Assert.Fail();
-            await Task.Delay(100);
-            return "Lazy Async";
-        });
-
         var response = _factory.Render("Test/Page", new
         {
             Test = "Test",
             TestFunc = new Func<string>(() => "Func"),
-            TestLazy = _factory.Lazy(testFunction)
+            TestLazy = _factory.Lazy(() =>
+            {
+                Assert.Fail();
+                return Task.FromResult<object?>("Lazy Async");
+            })
         });
 
         var context = PrepareContext();
@@ -104,16 +101,10 @@ public partial class Tests
     [Description("Test if the lazy async data is fetched properly with specified partial props.")]
     public async Task TestLazyAsyncPartialData()
     {
-        var testFunction = new Func<Task<string>>(async () =>
-        {
-            await Task.Delay(100);
-            return "Lazy Async";
-        });
-
         var response = _factory.Render("Test/Page", new
         {
             TestFunc = new Func<string>(() => "Func"),
-            TestLazy = _factory.Lazy(async () => await testFunction())
+            TestLazy = _factory.Lazy(() => Task.FromResult<object?>("Lazy Async"))
         });
 
         var headers = new HeaderDictionary

--- a/InertiaCoreTests/UnitTestModelState.cs
+++ b/InertiaCoreTests/UnitTestModelState.cs
@@ -13,7 +13,7 @@ public partial class Tests
             Test = "Test"
         });
 
-        var context = PrepareContext(null, null, new Dictionary<string, string>
+        var context = PrepareContext(null, new Dictionary<string, string>
         {
             { "Field", "Error" }
         });

--- a/InertiaCoreTests/UnitTestModelState.cs
+++ b/InertiaCoreTests/UnitTestModelState.cs
@@ -13,7 +13,7 @@ public partial class Tests
             Test = "Test"
         });
 
-        var context = PrepareContext(null, new Dictionary<string, string>
+        var context = PrepareContext(null, null, new Dictionary<string, string>
         {
             { "Field", "Error" }
         });

--- a/InertiaCoreTests/UnitTestSharedData.cs
+++ b/InertiaCoreTests/UnitTestSharedData.cs
@@ -9,15 +9,14 @@ public partial class Tests
     [Description("Test if shared data is merged with the props properly.")]
     public async Task TestSharedData()
     {
+        _factory.Share("TestShared", "Shared");
+
         var response = _factory.Render("Test/Page", new
         {
             Test = "Test"
         });
 
-        var sharedData = new InertiaSharedData();
-        sharedData.Set("TestShared", "Shared");
-
-        var context = PrepareContext(null, sharedData);
+        var context = PrepareContext();
 
         response.SetContext(context);
         await response.ProcessResponse();

--- a/InertiaCoreTests/UnitTestSharedData.cs
+++ b/InertiaCoreTests/UnitTestSharedData.cs
@@ -7,16 +7,17 @@ public partial class Tests
 {
     [Test]
     [Description("Test if shared data is merged with the props properly.")]
-    public async Task TestSharedData()
+    public async Task TestSharedProps()
     {
-        _factory.Share("TestShared", "Shared");
-
         var response = _factory.Render("Test/Page", new
         {
             Test = "Test"
         });
 
-        var context = PrepareContext();
+        var sharedProps = new InertiaSharedProps();
+        sharedProps.Set("TestShared", "Shared");
+
+        var context = PrepareContext(null, sharedProps);
 
         response.SetContext(context);
         await response.ProcessResponse();


### PR DESCRIPTION
In this PR, I've changed a lot of the resolving functionality, including resolving properties inside nested dictionaries. Now it should resolve the properties in the same way as the original [inertiajs/inertia-laravel](https://github.com/inertiajs/inertia-laravel) adapter.

These changes can also be merged to the `main` branch.