### PR TITLE
[1.x] Added automatic Vite versioning

### DIFF
--- a/InertiaCore/Extensions/Configure.cs
+++ b/InertiaCore/Extensions/Configure.cs
@@ -21,7 +21,7 @@ public static class Configure
         if (viteBuilder != null)
         {
             Vite.UseBuilder(viteBuilder);
-            Inertia.Version(() => Vite.GetManifestHash());
+            Inertia.Version(Vite.GetManifestHash);
         }
 
         app.Use(async (context, next) =>

--- a/InertiaCore/Extensions/Configure.cs
+++ b/InertiaCore/Extensions/Configure.cs
@@ -18,7 +18,11 @@ public static class Configure
         Inertia.UseFactory(factory);
 
         var viteBuilder = app.ApplicationServices.GetService<IViteBuilder>();
-        if (viteBuilder != null) Vite.UseBuilder(viteBuilder);
+        if (viteBuilder != null)
+        {
+            Vite.UseBuilder(viteBuilder);
+            Inertia.Version(() => Vite.GetManifestHash());
+        }
 
         app.Use(async (context, next) =>
         {

--- a/InertiaCore/Extensions/InertiaExtensions.cs
+++ b/InertiaCore/Extensions/InertiaExtensions.cs
@@ -3,6 +3,7 @@ using InertiaCore.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using System.Text;
 
 namespace InertiaCore.Extensions;
 
@@ -48,5 +49,18 @@ internal static class InertiaExtensions
         var result = task.GetType().GetProperty("Result");
 
         return result?.GetValue(task);
+    }
+
+    internal static string MD5(this string s)
+    {
+        using var md5 = System.Security.Cryptography.MD5.Create();
+        var inputBytes = Encoding.UTF8.GetBytes(s);
+        var hashBytes = md5.ComputeHash(inputBytes);
+
+        var sb = new StringBuilder();
+        foreach (var t in hashBytes)
+            sb.Append(t.ToString("x2"));
+
+        return sb.ToString();
     }
 }

--- a/InertiaCore/Inertia.cs
+++ b/InertiaCore/Inertia.cs
@@ -19,7 +19,9 @@ public static class Inertia
 
     public static Task<IHtmlContent> Html(dynamic model) => _factory.Html(model);
 
-    public static void Version(object? version) => _factory.Version(version);
+    public static void Version(string? version) => _factory.Version(version);
+
+    public static void Version(Func<string?> version) => _factory.Version(version);
 
     public static string? GetVersion() => _factory.GetVersion();
 
@@ -29,9 +31,9 @@ public static class Inertia
 
     public static void Share(IDictionary<string, object?> data) => _factory.Share(data);
 
-    public static AlwaysProp Always(object? value) => _factory.Always(value);
+    public static AlwaysProp Always(string value) => _factory.Always(value);
 
-    public static AlwaysProp Always(Func<object?> callback) => _factory.Always(callback);
+    public static AlwaysProp Always(Func<string> callback) => _factory.Always(callback);
 
     public static AlwaysProp Always(Func<Task<object?>> callback) => _factory.Always(callback);
 

--- a/InertiaCore/ResponseFactory.cs
+++ b/InertiaCore/ResponseFactory.cs
@@ -16,7 +16,8 @@ internal interface IResponseFactory
     public Response Render(string component, object? props = null);
     public Task<IHtmlContent> Head(dynamic model);
     public Task<IHtmlContent> Html(dynamic model);
-    public void Version(object? version);
+    public void Version(string? version);
+    public void Version(Func<string?> version);
     public string? GetVersion();
     public LocationResult Location(string url);
     public void Share(string key, object? value);
@@ -95,7 +96,9 @@ internal class ResponseFactory : IResponseFactory
         return new HtmlString($"<div id=\"app\" data-page=\"{encoded}\"></div>");
     }
 
-    public void Version(object? version) => _version = version;
+    public void Version(string? version) => _version = version;
+
+    public void Version(Func<string?> version) => _version = version;
 
     public string? GetVersion() => _version switch
     {

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.IO.Abstractions;
 using InertiaCore.Models;
 using Microsoft.Extensions.Options;
+using InertiaCore.Extensions;
 
 namespace InertiaCore.Utils;
 
@@ -13,6 +14,7 @@ public interface IViteBuilder
 {
     HtmlString ReactRefresh();
     HtmlString Input(string path);
+    string? GetManifest();
 }
 
 internal class ViteBuilder : IViteBuilder
@@ -205,6 +207,16 @@ internal class ViteBuilder : IViteBuilder
         content.WriteTo(writer, HtmlEncoder.Default);
         return writer.ToString();
     }
+
+    public string? GetManifest()
+    {
+        if (_fileSystem.File.Exists(GetPublicPathForFile(_options.Value.ManifestFilename)))
+        {
+            return _fileSystem.File.ReadAllText(GetPublicPathForFile(_options.Value.ManifestFilename));
+        }
+
+        return null;
+    }
 }
 
 public static class Vite
@@ -222,4 +234,9 @@ public static class Vite
     /// Generate React refresh runtime script.
     /// </summary>
     public static HtmlString ReactRefresh() => _instance.ReactRefresh();
+
+    /// <summary>
+    /// Generate the Manifest hash.
+    /// </summary>
+    public static string? GetManifestHash() => _instance.GetManifest()?.MD5();
 }

--- a/InertiaCore/Utils/Vite.cs
+++ b/InertiaCore/Utils/Vite.cs
@@ -67,12 +67,11 @@ internal class ViteBuilder : IViteBuilder
             throw new Exception("Vite Manifest is invalid. Run `npm run build` and try again.");
         }
 
-        if (!manifestJson.ContainsKey(path))
+        if (!manifestJson.TryGetValue(path, out var obj))
         {
             throw new Exception("Asset not found in manifest: " + path);
         }
 
-        var obj = manifestJson[path];
         var filePath = obj.GetProperty("file");
 
         if (IsCssPath(filePath.ToString()))
@@ -210,12 +209,9 @@ internal class ViteBuilder : IViteBuilder
 
     public string? GetManifest()
     {
-        if (_fileSystem.File.Exists(GetPublicPathForFile(_options.Value.ManifestFilename)))
-        {
-            return _fileSystem.File.ReadAllText(GetPublicPathForFile(_options.Value.ManifestFilename));
-        }
-
-        return null;
+        return _fileSystem.File.Exists(GetPublicPathForFile(_options.Value.ManifestFilename))
+            ? _fileSystem.File.ReadAllText(GetPublicPathForFile(_options.Value.ManifestFilename))
+            : null;
     }
 }
 

--- a/InertiaCoreTests/UnitTestVite.cs
+++ b/InertiaCoreTests/UnitTestVite.cs
@@ -3,11 +3,10 @@ using InertiaCore.Extensions;
 using InertiaCore.Models;
 using InertiaCore.Utils;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Moq;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace InertiaCoreTests;
 
@@ -73,7 +72,8 @@ public partial class Tests
     }
 
     [Test]
-    [Description("Test if the Vite Helper handles generating HTML tags for both JS and CSS from HMR and the manifest properly.")]
+    [Description(
+        "Test if the Vite Helper handles generating HTML tags for both JS and CSS from HMR and the manifest properly.")]
     public void TestViteInput()
     {
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
@@ -226,7 +226,7 @@ public partial class Tests
         fileSystem.AddFile(@"/wwwroot/build/manifest.json",
             new MockFileData("{\"app.tsx\": {\"file\": \"assets/main-19038c6a.js\"}}"));
 
-        _factory.Version(() => Vite.GetManifestHash());
+        _factory.Version(Vite.GetManifestHash);
 
         var response = _factory.Render("Test/Page", new
         {
@@ -247,7 +247,7 @@ public partial class Tests
 
         Assert.Multiple(() =>
         {
-            Assert.That(result, Is.InstanceOf(typeof(JsonResult)));
+            Assert.That(result, Is.InstanceOf<JsonResult>());
 
             var json = (result as JsonResult)?.Value;
             Assert.That((json as Page)?.Version, Is.EqualTo("bba1afd1066309f4a69430e0c446ba8d"));


### PR DESCRIPTION
When using Vite, this will automatically pull the manifest hash as the version for the front-end.

This should check the first two boxes in https://github.com/kapi2289/InertiaCore/issues/28.