### PR TITLE
[1.x] Back function

### DIFF
--- a/InertiaCore/Inertia.cs
+++ b/InertiaCore/Inertia.cs
@@ -27,6 +27,8 @@ public static class Inertia
 
     public static LocationResult Location(string url) => _factory.Location(url);
 
+    public static BackResult Back(string? fallbackUrl = null) => _factory.Back(fallbackUrl);
+
     public static void Share(string key, object? value) => _factory.Share(key, value);
 
     public static void Share(IDictionary<string, object?> data) => _factory.Share(data);

--- a/InertiaCore/Models/InertiaOptions.cs
+++ b/InertiaCore/Models/InertiaOptions.cs
@@ -6,4 +6,5 @@ public class InertiaOptions
 
     public bool SsrEnabled { get; set; } = false;
     public string SsrUrl { get; set; } = "http://127.0.0.1:13714/render";
+    public bool EncryptHistory { get; set; } = false;
 }

--- a/InertiaCore/Models/Page.cs
+++ b/InertiaCore/Models/Page.cs
@@ -6,4 +6,6 @@ internal class Page
     public string Component { get; set; } = default!;
     public string? Version { get; set; }
     public string Url { get; set; } = default!;
+    public bool EncryptHistory { get; set; } = false;
+    public bool ClearHistory { get; set; } = false;
 }

--- a/InertiaCore/Response.cs
+++ b/InertiaCore/Response.cs
@@ -16,13 +16,15 @@ public class Response : IActionResult
     private readonly Dictionary<string, object?> _props;
     private readonly string _rootView;
     private readonly string? _version;
+    private readonly bool _encryptHistory;
+    private readonly bool _clearHistory;
 
     private ActionContext? _context;
     private Page? _page;
     private IDictionary<string, object>? _viewData;
 
-    internal Response(string component, Dictionary<string, object?> props, string rootView, string? version)
-        => (_component, _props, _rootView, _version) = (component, props, rootView, version);
+    internal Response(string component, Dictionary<string, object?> props, string rootView, string? version, bool encryptHistory, bool clearHistory)
+        => (_component, _props, _rootView, _version, _encryptHistory, _clearHistory) = (component, props, rootView, version, encryptHistory, clearHistory);
 
     public async Task ExecuteResultAsync(ActionContext context)
     {
@@ -40,7 +42,9 @@ public class Response : IActionResult
             Component = _component,
             Version = _version,
             Url = _context!.RequestedUri(),
-            Props = props
+            Props = props,
+            EncryptHistory = _encryptHistory,
+            ClearHistory = _clearHistory,
         };
 
         page.Props["errors"] = GetErrors();
@@ -169,7 +173,7 @@ public class Response : IActionResult
     protected internal JsonResult GetJson()
     {
         _context!.HttpContext.Response.Headers.Override(InertiaHeader.Inertia, "true");
-        _context!.HttpContext.Response.Headers.Override("Vary", "Accept");
+        _context!.HttpContext.Response.Headers.Override("Vary", InertiaHeader.Inertia);
         _context!.HttpContext.Response.StatusCode = 200;
 
         return new JsonResult(_page, new JsonSerializerOptions

--- a/InertiaCore/ResponseFactory.cs
+++ b/InertiaCore/ResponseFactory.cs
@@ -22,6 +22,8 @@ internal interface IResponseFactory
     public LocationResult Location(string url);
     public void Share(string key, object? value);
     public void Share(IDictionary<string, object?> data);
+    public void ClearHistory(bool clear = true);
+    public void EncryptHistory(bool encrypt = true);
     public AlwaysProp Always(object? value);
     public AlwaysProp Always(Func<object?> callback);
     public AlwaysProp Always(Func<Task<object?>> callback);
@@ -36,6 +38,8 @@ internal class ResponseFactory : IResponseFactory
     private readonly IOptions<InertiaOptions> _options;
 
     private object? _version;
+    private bool _clearHistory;
+    private bool? _encryptHistory;
 
     public ResponseFactory(IHttpContextAccessor contextAccessor, IGateway gateway, IOptions<InertiaOptions> options) =>
         (_contextAccessor, _gateway, _options) = (contextAccessor, gateway, options);
@@ -50,7 +54,7 @@ internal class ResponseFactory : IResponseFactory
                 .ToDictionary(o => o.Name, o => o.GetValue(props))
         };
 
-        return new Response(component, dictProps, _options.Value.RootView, GetVersion());
+        return new Response(component, dictProps, _options.Value.RootView, GetVersion(), _encryptHistory ?? _options.Value.EncryptHistory, _clearHistory);
     }
 
     public async Task<IHtmlContent> Head(dynamic model)
@@ -130,6 +134,10 @@ internal class ResponseFactory : IResponseFactory
 
         context.Features.Set(sharedData);
     }
+
+    public void ClearHistory(bool clear = true) => _clearHistory = clear;
+
+    public void EncryptHistory(bool encrypt = true) => _encryptHistory = encrypt;
 
     public LazyProp Lazy(Func<object?> callback) => new(callback);
     public LazyProp Lazy(Func<Task<object?>> callback) => new(callback);

--- a/InertiaCore/ResponseFactory.cs
+++ b/InertiaCore/ResponseFactory.cs
@@ -20,6 +20,7 @@ internal interface IResponseFactory
     public void Version(Func<string?> version);
     public string? GetVersion();
     public LocationResult Location(string url);
+    public BackResult Back(string? fallbackUrl = null);
     public void Share(string key, object? value);
     public void Share(IDictionary<string, object?> data);
     public void ClearHistory(bool clear = true);
@@ -112,6 +113,7 @@ internal class ResponseFactory : IResponseFactory
     };
 
     public LocationResult Location(string url) => new(url);
+    public BackResult Back(string? fallbackUrl = null) => new(fallbackUrl);
 
     public void Share(string key, object? value)
     {

--- a/InertiaCore/Utils/BackResult.cs
+++ b/InertiaCore/Utils/BackResult.cs
@@ -15,13 +15,6 @@ public class BackResult : IActionResult
         var referrer = context.HttpContext.Request.Headers.Referer.ToString();
         var redirectUrl = !string.IsNullOrEmpty(referrer) ? referrer : _fallbackUrl;
 
-        if (context.IsInertiaRequest())
-        {
-            context.HttpContext.Response.Headers.Override(InertiaHeader.Location, redirectUrl);
-            await new StatusCodeResult((int)HttpStatusCode.Conflict).ExecuteResultAsync(context);
-            return;
-        }
-
         await new RedirectResult(redirectUrl).ExecuteResultAsync(context);
     }
 }

--- a/InertiaCore/Utils/BackResult.cs
+++ b/InertiaCore/Utils/BackResult.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using InertiaCore.Extensions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InertiaCore.Utils;
+
+public class BackResult : IActionResult
+{
+    private readonly string _fallbackUrl;
+
+    public BackResult(string? fallbackUrl = null) => _fallbackUrl = fallbackUrl ?? "/";
+
+    public async Task ExecuteResultAsync(ActionContext context)
+    {
+        var referrer = context.HttpContext.Request.Headers.Referer.ToString();
+        var redirectUrl = !string.IsNullOrEmpty(referrer) ? referrer : _fallbackUrl;
+
+        if (context.IsInertiaRequest())
+        {
+            context.HttpContext.Response.Headers.Override(InertiaHeader.Location, redirectUrl);
+            await new StatusCodeResult((int)HttpStatusCode.Conflict).ExecuteResultAsync(context);
+            return;
+        }
+
+        await new RedirectResult(redirectUrl).ExecuteResultAsync(context);
+    }
+}

--- a/InertiaCoreTests/UnitTestBack.cs
+++ b/InertiaCoreTests/UnitTestBack.cs
@@ -16,7 +16,7 @@ namespace InertiaCoreTests;
 public partial class Tests
 {
     [Test]
-    [Description("Test Back function with Inertia request returns conflict status with location header.")]
+    [Description("Test Back function with Inertia request returns redirect status with location header.")]
     public async Task TestBackWithInertiaRequest()
     {
         var backResult = _factory.Back("/fallback");
@@ -52,10 +52,10 @@ public partial class Tests
 
         Assert.Multiple(() =>
         {
-            Assert.That(responseHeaders.ContainsKey("X-Inertia-Location"), Is.True);
-            Assert.That(responseHeaders["X-Inertia-Location"].ToString(), Is.EqualTo("back"));
-            // Verify that status code 409 (Conflict) is set
-            response.VerifySet(r => r.StatusCode = (int)HttpStatusCode.Conflict, Times.Once);
+            Assert.That(responseHeaders.ContainsKey("Location"), Is.True);
+            Assert.That(responseHeaders["Location"].ToString(), Is.EqualTo("back"));
+            // Verify that status code 302 (Redirect) is set
+            response.VerifySet(r => r.StatusCode = (int)HttpStatusCode.Redirect, Times.Once);
         });
     }
 

--- a/InertiaCoreTests/UnitTestBack.cs
+++ b/InertiaCoreTests/UnitTestBack.cs
@@ -104,9 +104,6 @@ public partial class Tests
         Assert.That(result, Is.Not.Null);
 
         await result.ExecuteResultAsync(context);
-
-        // The BackResult should use the referrer URL since the request is not an Inertia request
-        Assert.Pass("Back function correctly handled referrer redirect");
     }
 
     [Test]
@@ -151,9 +148,6 @@ public partial class Tests
         Assert.That(result, Is.Not.Null);
 
         await result.ExecuteResultAsync(context);
-
-        // The BackResult should use the fallback URL since there is no referrer
-        Assert.Pass("Back function correctly used fallback URL");
     }
 
     [Test]
@@ -197,9 +191,6 @@ public partial class Tests
         Assert.That(result, Is.Not.Null);
 
         await result.ExecuteResultAsync(context);
-
-        // The BackResult should use the default "/" URL since there is no referrer and no fallback provided
-        Assert.Pass("Back function correctly used default fallback");
     }
 
 }

--- a/InertiaCoreTests/UnitTestBack.cs
+++ b/InertiaCoreTests/UnitTestBack.cs
@@ -1,0 +1,197 @@
+using System.Net;
+using InertiaCore;
+using InertiaCore.Extensions;
+using InertiaCore.Utils;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace InertiaCoreTests;
+
+public partial class Tests
+{
+    [Test]
+    [Description("Test Back function with Inertia request returns conflict status with location header.")]
+    public async Task TestBackWithInertiaRequest()
+    {
+        var backResult = _factory.Back("/fallback");
+
+        var headers = new HeaderDictionary
+        {
+            { "X-Inertia", "true" }
+        };
+
+        var responseHeaders = new HeaderDictionary();
+        var response = new Mock<HttpResponse>();
+        response.SetupGet(r => r.Headers).Returns(responseHeaders);
+        response.SetupGet(r => r.StatusCode).Returns(0);
+        response.SetupSet(r => r.StatusCode = It.IsAny<int>());
+
+        var request = new Mock<HttpRequest>();
+        request.SetupGet(r => r.Headers).Returns(headers);
+
+        // Set up service provider
+        var services = new ServiceCollection();
+        services.AddSingleton<IActionResultExecutor<StatusCodeResult>>(new Mock<IActionResultExecutor<StatusCodeResult>>().Object);
+        services.AddLogging();
+        var serviceProvider = services.BuildServiceProvider();
+
+        var httpContext = new Mock<HttpContext>();
+        httpContext.SetupGet(c => c.Request).Returns(request.Object);
+        httpContext.SetupGet(c => c.Response).Returns(response.Object);
+        httpContext.SetupGet(c => c.RequestServices).Returns(serviceProvider);
+
+        var context = new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
+
+        await backResult.ExecuteResultAsync(context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(responseHeaders.ContainsKey("X-Inertia-Location"), Is.True);
+            Assert.That(responseHeaders["X-Inertia-Location"].ToString(), Is.EqualTo("back"));
+            // Verify that status code 409 (Conflict) is set
+            response.VerifySet(r => r.StatusCode = (int)HttpStatusCode.Conflict, Times.Once);
+        });
+    }
+
+    [Test]
+    [Description("Test Back function with regular request and referrer header redirects to referrer.")]
+    public async Task TestBackWithReferrerHeader()
+    {
+        var backResult = _factory.Back("/fallback");
+
+        var headers = new HeaderDictionary
+        {
+            { "Referer", "https://example.com/previous-page" }
+        };
+
+        var responseHeaders = new HeaderDictionary();
+        string? redirectLocation = null;
+        var response = new Mock<HttpResponse>();
+        response.SetupGet(r => r.Headers).Returns(responseHeaders);
+        response.SetupGet(r => r.StatusCode).Returns(0);
+        response.SetupSet(r => r.StatusCode = It.IsAny<int>());
+        response.Setup(r => r.Redirect(It.IsAny<string>()))
+            .Callback<string>(location => redirectLocation = location);
+
+        var request = new Mock<HttpRequest>();
+        request.SetupGet(r => r.Headers).Returns(headers);
+        request.SetupGet(r => r.Scheme).Returns("https");
+        request.SetupGet(r => r.Host).Returns(new HostString("example.com"));
+
+        // Set up service provider
+        var services = new ServiceCollection();
+        services.AddSingleton<IActionResultExecutor<RedirectResult>>(new Mock<IActionResultExecutor<RedirectResult>>().Object);
+        services.AddSingleton<ILoggerFactory>(new Mock<ILoggerFactory>().Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var httpContext = new Mock<HttpContext>();
+        httpContext.SetupGet(c => c.Request).Returns(request.Object);
+        httpContext.SetupGet(c => c.Response).Returns(response.Object);
+        httpContext.SetupGet(c => c.RequestServices).Returns(serviceProvider);
+
+        var context = new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
+
+        var result = backResult as IActionResult;
+        Assert.That(result, Is.Not.Null);
+
+        await result.ExecuteResultAsync(context);
+
+        // The BackResult should use the referrer URL since the request is not an Inertia request
+        Assert.Pass("Back function correctly handled referrer redirect");
+    }
+
+    [Test]
+    [Description("Test Back function without referrer uses fallback URL.")]
+    public async Task TestBackWithFallbackUrl()
+    {
+        var backResult = _factory.Back("/custom-fallback");
+
+        var headers = new HeaderDictionary();
+
+        var responseHeaders = new HeaderDictionary();
+        string? redirectLocation = null;
+        var response = new Mock<HttpResponse>();
+        response.SetupGet(r => r.Headers).Returns(responseHeaders);
+        response.SetupGet(r => r.StatusCode).Returns(0);
+        response.SetupSet(r => r.StatusCode = It.IsAny<int>());
+        response.Setup(r => r.Redirect(It.IsAny<string>()))
+            .Callback<string>(location => redirectLocation = location);
+
+        var request = new Mock<HttpRequest>();
+        request.SetupGet(r => r.Headers).Returns(headers);
+        request.SetupGet(r => r.Scheme).Returns("https");
+        request.SetupGet(r => r.Host).Returns(new HostString("example.com"));
+
+        // Set up service provider
+        var services = new ServiceCollection();
+        services.AddSingleton<IActionResultExecutor<RedirectResult>>(new Mock<IActionResultExecutor<RedirectResult>>().Object);
+        services.AddSingleton<ILoggerFactory>(new Mock<ILoggerFactory>().Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var httpContext = new Mock<HttpContext>();
+        httpContext.SetupGet(c => c.Request).Returns(request.Object);
+        httpContext.SetupGet(c => c.Response).Returns(response.Object);
+        httpContext.SetupGet(c => c.RequestServices).Returns(serviceProvider);
+
+        var context = new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
+
+        var result = backResult as IActionResult;
+        Assert.That(result, Is.Not.Null);
+
+        await result.ExecuteResultAsync(context);
+
+        // The BackResult should use the fallback URL since there is no referrer
+        Assert.Pass("Back function correctly used fallback URL");
+    }
+
+    [Test]
+    [Description("Test Back function without fallback URL uses default root path.")]
+    public async Task TestBackWithDefaultFallback()
+    {
+        var backResult = _factory.Back();
+
+        var headers = new HeaderDictionary();
+
+        var responseHeaders = new HeaderDictionary();
+        string? redirectLocation = null;
+        var response = new Mock<HttpResponse>();
+        response.SetupGet(r => r.Headers).Returns(responseHeaders);
+        response.SetupGet(r => r.StatusCode).Returns(0);
+        response.SetupSet(r => r.StatusCode = It.IsAny<int>());
+        response.Setup(r => r.Redirect(It.IsAny<string>()))
+            .Callback<string>(location => redirectLocation = location);
+
+        var request = new Mock<HttpRequest>();
+        request.SetupGet(r => r.Headers).Returns(headers);
+        request.SetupGet(r => r.Scheme).Returns("https");
+        request.SetupGet(r => r.Host).Returns(new HostString("example.com"));
+
+        // Set up service provider
+        var services = new ServiceCollection();
+        services.AddSingleton<IActionResultExecutor<RedirectResult>>(new Mock<IActionResultExecutor<RedirectResult>>().Object);
+        services.AddSingleton<ILoggerFactory>(new Mock<ILoggerFactory>().Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var httpContext = new Mock<HttpContext>();
+        httpContext.SetupGet(c => c.Request).Returns(request.Object);
+        httpContext.SetupGet(c => c.Response).Returns(response.Object);
+        httpContext.SetupGet(c => c.RequestServices).Returns(serviceProvider);
+
+        var context = new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
+
+        var result = backResult as IActionResult;
+        Assert.That(result, Is.Not.Null);
+
+        await result.ExecuteResultAsync(context);
+
+        // The BackResult should use the default "/" URL since there is no referrer and no fallback provided
+        Assert.Pass("Back function correctly used default fallback");
+    }
+
+}

--- a/InertiaCoreTests/UnitTestHistory.cs
+++ b/InertiaCoreTests/UnitTestHistory.cs
@@ -1,0 +1,90 @@
+using InertiaCore.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InertiaCoreTests;
+
+public partial class Tests
+{
+    [Test]
+    [Description("Test if history encryption is sent correctly.")]
+    public async Task TestHistoryEncryptionResult()
+    {
+        _factory.EncryptHistory();
+
+        var response = _factory.Render("Test/Page", new
+        {
+            Test = "Test"
+        });
+
+        var headers = new HeaderDictionary
+        {
+            { "X-Inertia", "true" }
+        };
+
+        var context = PrepareContext(headers);
+
+        response.SetContext(context);
+        await response.ProcessResponse();
+
+        var result = response.GetResult();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.InstanceOf<JsonResult>());
+
+            var json = (result as JsonResult)?.Value;
+            Assert.That(json, Is.InstanceOf<Page>());
+
+            Assert.That((json as Page)?.ClearHistory, Is.EqualTo(false));
+            Assert.That((json as Page)?.EncryptHistory, Is.EqualTo(true));
+            Assert.That((json as Page)?.Component, Is.EqualTo("Test/Page"));
+            Assert.That((json as Page)?.Props, Is.EqualTo(new Dictionary<string, object?>
+            {
+                { "test", "Test" },
+                { "errors", new Dictionary<string, string>(0) }
+            }));
+        });
+    }
+
+    [Test]
+    [Description("Test if clear history is sent correctly.")]
+    public async Task TestClearHistoryResult()
+    {
+        _factory.ClearHistory();
+
+        var response = _factory.Render("Test/Page", new
+        {
+            Test = "Test"
+        });
+
+        var headers = new HeaderDictionary
+        {
+            { "X-Inertia", "true" }
+        };
+
+        var context = PrepareContext(headers);
+
+        response.SetContext(context);
+        await response.ProcessResponse();
+
+        var result = response.GetResult();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.InstanceOf<JsonResult>());
+
+            var json = (result as JsonResult)?.Value;
+            Assert.That(json, Is.InstanceOf<Page>());
+
+            Assert.That((json as Page)?.ClearHistory, Is.EqualTo(true));
+            Assert.That((json as Page)?.EncryptHistory, Is.EqualTo(false));
+            Assert.That((json as Page)?.Component, Is.EqualTo("Test/Page"));
+            Assert.That((json as Page)?.Props, Is.EqualTo(new Dictionary<string, object?>
+            {
+                { "test", "Test" },
+                { "errors", new Dictionary<string, string>(0) }
+            }));
+        });
+    }
+}


### PR DESCRIPTION
Much of the time, I like to be able simply redirect back to the request came from on POST requests. This allows for something like:


```csharp
using InertiaCore;
using Microsoft.AspNetCore.Mvc;

namespace TestCsrf.Controllers;

public class FormController : Controller
{
    public IActionResult Index()
    {
        var props = new
        {
            Success = TempData["SuccessMessage"] != null,
            Message = TempData["SuccessMessage"]?.ToString()
        };

        return Inertia.Render("Form", props);
    }

    [HttpPost]
    public IActionResult Submit([FromForm] SubmitFormRequest request)
    {
        if (!ModelState.IsValid)
        {
            return Inertia.Back();
        }

        // Process the form data
        TempData["SuccessMessage"] = $"Form submitted successfully! Name: {request.Name}, Email: {request.Email}";

        return Inertia.Back();
    }
}

public class SubmitFormRequest
{
    public string Name { get; set; } = string.Empty;
    public string Email { get; set; } = string.Empty;
    public string Message { get; set; } = string.Empty;
}
```