### PR TITLE
[1.x] Back function

### DIFF
--- a/InertiaCore/Inertia.cs
+++ b/InertiaCore/Inertia.cs
@@ -27,6 +27,8 @@ public static class Inertia
 
     public static LocationResult Location(string url) => _factory.Location(url);
 
+    public static BackResult Back(string? fallbackUrl = null) => _factory.Back(fallbackUrl);
+
     public static void Share(string key, object? value) => _factory.Share(key, value);
 
     public static void Share(IDictionary<string, object?> data) => _factory.Share(data);

--- a/InertiaCore/Inertia.cs
+++ b/InertiaCore/Inertia.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Net;
+using System.Runtime.CompilerServices;
 using InertiaCore.Props;
 using InertiaCore.Utils;
 using Microsoft.AspNetCore.Html;
@@ -27,7 +28,7 @@ public static class Inertia
 
     public static LocationResult Location(string url) => _factory.Location(url);
 
-    public static BackResult Back(string? fallbackUrl = null) => _factory.Back(fallbackUrl);
+    public static BackResult Back(string? fallbackUrl = null, HttpStatusCode statusCode = HttpStatusCode.SeeOther) => _factory.Back(fallbackUrl, statusCode);
 
     public static void Share(string key, object? value) => _factory.Share(key, value);
 

--- a/InertiaCore/Inertia.cs
+++ b/InertiaCore/Inertia.cs
@@ -28,7 +28,8 @@ public static class Inertia
 
     public static LocationResult Location(string url) => _factory.Location(url);
 
-    public static BackResult Back(string? fallbackUrl = null, HttpStatusCode statusCode = HttpStatusCode.SeeOther) => _factory.Back(fallbackUrl, statusCode);
+    public static BackResult Back(string? fallbackUrl = null, HttpStatusCode statusCode = HttpStatusCode.SeeOther) =>
+        _factory.Back(fallbackUrl, statusCode);
 
     public static void Share(string key, object? value) => _factory.Share(key, value);
 

--- a/InertiaCore/ResponseFactory.cs
+++ b/InertiaCore/ResponseFactory.cs
@@ -20,6 +20,7 @@ internal interface IResponseFactory
     public void Version(Func<string?> version);
     public string? GetVersion();
     public LocationResult Location(string url);
+    public BackResult Back(string? fallbackUrl = null);
     public void Share(string key, object? value);
     public void Share(IDictionary<string, object?> data);
     public AlwaysProp Always(object? value);
@@ -108,6 +109,7 @@ internal class ResponseFactory : IResponseFactory
     };
 
     public LocationResult Location(string url) => new(url);
+    public BackResult Back(string? fallbackUrl = null) => new(fallbackUrl);
 
     public void Share(string key, object? value)
     {

--- a/InertiaCore/ResponseFactory.cs
+++ b/InertiaCore/ResponseFactory.cs
@@ -20,7 +20,7 @@ internal interface IResponseFactory
     public void Version(Func<string?> version);
     public string? GetVersion();
     public LocationResult Location(string url);
-    public BackResult Back(string? fallbackUrl = null);
+    public BackResult Back(string? fallbackUrl = null, HttpStatusCode statusCode = HttpStatusCode.SeeOther);
     public void Share(string key, object? value);
     public void Share(IDictionary<string, object?> data);
     public AlwaysProp Always(object? value);
@@ -109,7 +109,7 @@ internal class ResponseFactory : IResponseFactory
     };
 
     public LocationResult Location(string url) => new(url);
-    public BackResult Back(string? fallbackUrl = null) => new(fallbackUrl);
+    public BackResult Back(string? fallbackUrl = null, HttpStatusCode statusCode = HttpStatusCode.SeeOther) => new(fallbackUrl, statusCode);
 
     public void Share(string key, object? value)
     {

--- a/InertiaCore/ResponseFactory.cs
+++ b/InertiaCore/ResponseFactory.cs
@@ -109,7 +109,9 @@ internal class ResponseFactory : IResponseFactory
     };
 
     public LocationResult Location(string url) => new(url);
-    public BackResult Back(string? fallbackUrl = null, HttpStatusCode statusCode = HttpStatusCode.SeeOther) => new(fallbackUrl, statusCode);
+
+    public BackResult Back(string? fallbackUrl = null, HttpStatusCode statusCode = HttpStatusCode.SeeOther) =>
+        new(fallbackUrl, statusCode);
 
     public void Share(string key, object? value)
     {

--- a/InertiaCore/Utils/BackResult.cs
+++ b/InertiaCore/Utils/BackResult.cs
@@ -15,13 +15,6 @@ public class BackResult : IActionResult
         var referrer = context.HttpContext.Request.Headers.Referer.ToString();
         var redirectUrl = !string.IsNullOrEmpty(referrer) ? referrer : _fallbackUrl;
 
-        if (context.IsInertiaRequest())
-        {
-            context.HttpContext.Response.Headers.Override(InertiaHeader.Location, redirectUrl);
-            await new StatusCodeResult((int)HttpStatusCode.Conflict).ExecuteResultAsync(context);
-            return;
-        }
-
         await new RedirectResult(redirectUrl).ExecuteResultAsync(context);
     }
 }

--- a/InertiaCore/Utils/BackResult.cs
+++ b/InertiaCore/Utils/BackResult.cs
@@ -7,14 +7,19 @@ namespace InertiaCore.Utils;
 public class BackResult : IActionResult
 {
     private readonly string _fallbackUrl;
+    private readonly HttpStatusCode _statusCode;
 
-    public BackResult(string? fallbackUrl = null) => _fallbackUrl = fallbackUrl ?? "/";
+    public BackResult(string? fallbackUrl = null, HttpStatusCode statusCode = HttpStatusCode.SeeOther) =>
+        (_fallbackUrl, _statusCode) = (fallbackUrl ?? "/", statusCode);
 
-    public async Task ExecuteResultAsync(ActionContext context)
+    public Task ExecuteResultAsync(ActionContext context)
     {
         var referrer = context.HttpContext.Request.Headers.Referer.ToString();
         var redirectUrl = !string.IsNullOrEmpty(referrer) ? referrer : _fallbackUrl;
 
-        await new RedirectResult(redirectUrl).ExecuteResultAsync(context);
+        context.HttpContext.Response.StatusCode = (int)_statusCode;
+        context.HttpContext.Response.Headers.Location = redirectUrl;
+
+        return Task.CompletedTask;
     }
 }

--- a/InertiaCore/Utils/BackResult.cs
+++ b/InertiaCore/Utils/BackResult.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using InertiaCore.Extensions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InertiaCore.Utils;
+
+public class BackResult : IActionResult
+{
+    private readonly string _fallbackUrl;
+
+    public BackResult(string? fallbackUrl = null) => _fallbackUrl = fallbackUrl ?? "/";
+
+    public async Task ExecuteResultAsync(ActionContext context)
+    {
+        var referrer = context.HttpContext.Request.Headers.Referer.ToString();
+        var redirectUrl = !string.IsNullOrEmpty(referrer) ? referrer : _fallbackUrl;
+
+        if (context.IsInertiaRequest())
+        {
+            context.HttpContext.Response.Headers.Override(InertiaHeader.Location, redirectUrl);
+            await new StatusCodeResult((int)HttpStatusCode.Conflict).ExecuteResultAsync(context);
+            return;
+        }
+
+        await new RedirectResult(redirectUrl).ExecuteResultAsync(context);
+    }
+}

--- a/InertiaCoreTests/UnitTestBack.cs
+++ b/InertiaCoreTests/UnitTestBack.cs
@@ -16,7 +16,7 @@ namespace InertiaCoreTests;
 public partial class Tests
 {
     [Test]
-    [Description("Test Back function with Inertia request returns conflict status with location header.")]
+    [Description("Test Back function with Inertia request returns redirect status with location header.")]
     public async Task TestBackWithInertiaRequest()
     {
         var backResult = _factory.Back("/fallback");
@@ -52,10 +52,10 @@ public partial class Tests
 
         Assert.Multiple(() =>
         {
-            Assert.That(responseHeaders.ContainsKey("X-Inertia-Location"), Is.True);
-            Assert.That(responseHeaders["X-Inertia-Location"].ToString(), Is.EqualTo("back"));
-            // Verify that status code 409 (Conflict) is set
-            response.VerifySet(r => r.StatusCode = (int)HttpStatusCode.Conflict, Times.Once);
+            Assert.That(responseHeaders.ContainsKey("Location"), Is.True);
+            Assert.That(responseHeaders["Location"].ToString(), Is.EqualTo("back"));
+            // Verify that status code 302 (Redirect) is set
+            response.VerifySet(r => r.StatusCode = (int)HttpStatusCode.Redirect, Times.Once);
         });
     }
 

--- a/InertiaCoreTests/UnitTestBack.cs
+++ b/InertiaCoreTests/UnitTestBack.cs
@@ -104,9 +104,6 @@ public partial class Tests
         Assert.That(result, Is.Not.Null);
 
         await result.ExecuteResultAsync(context);
-
-        // The BackResult should use the referrer URL since the request is not an Inertia request
-        Assert.Pass("Back function correctly handled referrer redirect");
     }
 
     [Test]
@@ -151,9 +148,6 @@ public partial class Tests
         Assert.That(result, Is.Not.Null);
 
         await result.ExecuteResultAsync(context);
-
-        // The BackResult should use the fallback URL since there is no referrer
-        Assert.Pass("Back function correctly used fallback URL");
     }
 
     [Test]
@@ -197,9 +191,6 @@ public partial class Tests
         Assert.That(result, Is.Not.Null);
 
         await result.ExecuteResultAsync(context);
-
-        // The BackResult should use the default "/" URL since there is no referrer and no fallback provided
-        Assert.Pass("Back function correctly used default fallback");
     }
 
 }

--- a/InertiaCoreTests/UnitTestBack.cs
+++ b/InertiaCoreTests/UnitTestBack.cs
@@ -1,0 +1,197 @@
+using System.Net;
+using InertiaCore;
+using InertiaCore.Extensions;
+using InertiaCore.Utils;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace InertiaCoreTests;
+
+public partial class Tests
+{
+    [Test]
+    [Description("Test Back function with Inertia request returns conflict status with location header.")]
+    public async Task TestBackWithInertiaRequest()
+    {
+        var backResult = _factory.Back("/fallback");
+
+        var headers = new HeaderDictionary
+        {
+            { "X-Inertia", "true" }
+        };
+
+        var responseHeaders = new HeaderDictionary();
+        var response = new Mock<HttpResponse>();
+        response.SetupGet(r => r.Headers).Returns(responseHeaders);
+        response.SetupGet(r => r.StatusCode).Returns(0);
+        response.SetupSet(r => r.StatusCode = It.IsAny<int>());
+
+        var request = new Mock<HttpRequest>();
+        request.SetupGet(r => r.Headers).Returns(headers);
+
+        // Set up service provider
+        var services = new ServiceCollection();
+        services.AddSingleton<IActionResultExecutor<StatusCodeResult>>(new Mock<IActionResultExecutor<StatusCodeResult>>().Object);
+        services.AddLogging();
+        var serviceProvider = services.BuildServiceProvider();
+
+        var httpContext = new Mock<HttpContext>();
+        httpContext.SetupGet(c => c.Request).Returns(request.Object);
+        httpContext.SetupGet(c => c.Response).Returns(response.Object);
+        httpContext.SetupGet(c => c.RequestServices).Returns(serviceProvider);
+
+        var context = new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
+
+        await backResult.ExecuteResultAsync(context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(responseHeaders.ContainsKey("X-Inertia-Location"), Is.True);
+            Assert.That(responseHeaders["X-Inertia-Location"].ToString(), Is.EqualTo("back"));
+            // Verify that status code 409 (Conflict) is set
+            response.VerifySet(r => r.StatusCode = (int)HttpStatusCode.Conflict, Times.Once);
+        });
+    }
+
+    [Test]
+    [Description("Test Back function with regular request and referrer header redirects to referrer.")]
+    public async Task TestBackWithReferrerHeader()
+    {
+        var backResult = _factory.Back("/fallback");
+
+        var headers = new HeaderDictionary
+        {
+            { "Referer", "https://example.com/previous-page" }
+        };
+
+        var responseHeaders = new HeaderDictionary();
+        string? redirectLocation = null;
+        var response = new Mock<HttpResponse>();
+        response.SetupGet(r => r.Headers).Returns(responseHeaders);
+        response.SetupGet(r => r.StatusCode).Returns(0);
+        response.SetupSet(r => r.StatusCode = It.IsAny<int>());
+        response.Setup(r => r.Redirect(It.IsAny<string>()))
+            .Callback<string>(location => redirectLocation = location);
+
+        var request = new Mock<HttpRequest>();
+        request.SetupGet(r => r.Headers).Returns(headers);
+        request.SetupGet(r => r.Scheme).Returns("https");
+        request.SetupGet(r => r.Host).Returns(new HostString("example.com"));
+
+        // Set up service provider
+        var services = new ServiceCollection();
+        services.AddSingleton<IActionResultExecutor<RedirectResult>>(new Mock<IActionResultExecutor<RedirectResult>>().Object);
+        services.AddSingleton<ILoggerFactory>(new Mock<ILoggerFactory>().Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var httpContext = new Mock<HttpContext>();
+        httpContext.SetupGet(c => c.Request).Returns(request.Object);
+        httpContext.SetupGet(c => c.Response).Returns(response.Object);
+        httpContext.SetupGet(c => c.RequestServices).Returns(serviceProvider);
+
+        var context = new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
+
+        var result = backResult as IActionResult;
+        Assert.That(result, Is.Not.Null);
+
+        await result.ExecuteResultAsync(context);
+
+        // The BackResult should use the referrer URL since the request is not an Inertia request
+        Assert.Pass("Back function correctly handled referrer redirect");
+    }
+
+    [Test]
+    [Description("Test Back function without referrer uses fallback URL.")]
+    public async Task TestBackWithFallbackUrl()
+    {
+        var backResult = _factory.Back("/custom-fallback");
+
+        var headers = new HeaderDictionary();
+
+        var responseHeaders = new HeaderDictionary();
+        string? redirectLocation = null;
+        var response = new Mock<HttpResponse>();
+        response.SetupGet(r => r.Headers).Returns(responseHeaders);
+        response.SetupGet(r => r.StatusCode).Returns(0);
+        response.SetupSet(r => r.StatusCode = It.IsAny<int>());
+        response.Setup(r => r.Redirect(It.IsAny<string>()))
+            .Callback<string>(location => redirectLocation = location);
+
+        var request = new Mock<HttpRequest>();
+        request.SetupGet(r => r.Headers).Returns(headers);
+        request.SetupGet(r => r.Scheme).Returns("https");
+        request.SetupGet(r => r.Host).Returns(new HostString("example.com"));
+
+        // Set up service provider
+        var services = new ServiceCollection();
+        services.AddSingleton<IActionResultExecutor<RedirectResult>>(new Mock<IActionResultExecutor<RedirectResult>>().Object);
+        services.AddSingleton<ILoggerFactory>(new Mock<ILoggerFactory>().Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var httpContext = new Mock<HttpContext>();
+        httpContext.SetupGet(c => c.Request).Returns(request.Object);
+        httpContext.SetupGet(c => c.Response).Returns(response.Object);
+        httpContext.SetupGet(c => c.RequestServices).Returns(serviceProvider);
+
+        var context = new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
+
+        var result = backResult as IActionResult;
+        Assert.That(result, Is.Not.Null);
+
+        await result.ExecuteResultAsync(context);
+
+        // The BackResult should use the fallback URL since there is no referrer
+        Assert.Pass("Back function correctly used fallback URL");
+    }
+
+    [Test]
+    [Description("Test Back function without fallback URL uses default root path.")]
+    public async Task TestBackWithDefaultFallback()
+    {
+        var backResult = _factory.Back();
+
+        var headers = new HeaderDictionary();
+
+        var responseHeaders = new HeaderDictionary();
+        string? redirectLocation = null;
+        var response = new Mock<HttpResponse>();
+        response.SetupGet(r => r.Headers).Returns(responseHeaders);
+        response.SetupGet(r => r.StatusCode).Returns(0);
+        response.SetupSet(r => r.StatusCode = It.IsAny<int>());
+        response.Setup(r => r.Redirect(It.IsAny<string>()))
+            .Callback<string>(location => redirectLocation = location);
+
+        var request = new Mock<HttpRequest>();
+        request.SetupGet(r => r.Headers).Returns(headers);
+        request.SetupGet(r => r.Scheme).Returns("https");
+        request.SetupGet(r => r.Host).Returns(new HostString("example.com"));
+
+        // Set up service provider
+        var services = new ServiceCollection();
+        services.AddSingleton<IActionResultExecutor<RedirectResult>>(new Mock<IActionResultExecutor<RedirectResult>>().Object);
+        services.AddSingleton<ILoggerFactory>(new Mock<ILoggerFactory>().Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var httpContext = new Mock<HttpContext>();
+        httpContext.SetupGet(c => c.Request).Returns(request.Object);
+        httpContext.SetupGet(c => c.Response).Returns(response.Object);
+        httpContext.SetupGet(c => c.RequestServices).Returns(serviceProvider);
+
+        var context = new ActionContext(httpContext.Object, new RouteData(), new ActionDescriptor());
+
+        var result = backResult as IActionResult;
+        Assert.That(result, Is.Not.Null);
+
+        await result.ExecuteResultAsync(context);
+
+        // The BackResult should use the default "/" URL since there is no referrer and no fallback provided
+        Assert.Pass("Back function correctly used default fallback");
+    }
+
+}

--- a/InertiaCoreTests/UnitTestBack.cs
+++ b/InertiaCoreTests/UnitTestBack.cs
@@ -1,16 +1,8 @@
-using System.Collections.Generic;
 using System.Net;
-using InertiaCore;
-using InertiaCore.Extensions;
-using InertiaCore.Utils;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace InertiaCoreTests;
@@ -179,5 +171,4 @@ public partial class Tests
         Assert.That(response.Object.StatusCode, Is.EqualTo(301));
         Assert.That(responseHeaders["Location"].ToString(), Is.EqualTo("/fallback"));
     }
-
 }


### PR DESCRIPTION
Recrated #36 due to not being based on v1:

This will be used when working on empty responses in #28 

Also, much of the time, I like to be able simply redirect back to the request came from on POST requests. This allows for something like:


```csharp
using InertiaCore;
using Microsoft.AspNetCore.Mvc;

namespace TestCsrf.Controllers;

public class FormController : Controller
{
    public IActionResult Index()
    {
        var props = new
        {
            Success = TempData["SuccessMessage"] != null,
            Message = TempData["SuccessMessage"]?.ToString()
        };

        return Inertia.Render("Form", props);
    }

    [HttpPost]
    public IActionResult Submit([FromForm] SubmitFormRequest request)
    {
        if (!ModelState.IsValid)
        {
            return Inertia.Back();
        }

        // Process the form data
        TempData["SuccessMessage"] = $"Form submitted successfully! Name: {request.Name}, Email: {request.Email}";

        return Inertia.Back();
    }
}

public class SubmitFormRequest
{
    public string Name { get; set; } = string.Empty;
    public string Email { get; set; } = string.Empty;
    public string Message { get; set; } = string.Empty;
}
```